### PR TITLE
REST API for direct_messages

### DIFF
--- a/twitter/direct_messages.go
+++ b/twitter/direct_messages.go
@@ -1,5 +1,10 @@
 package twitter
 
+import (
+	"github.com/dghubble/sling"
+	"net/http"
+)
+
 // DirectMessage is a direct message to a single recipient.
 type DirectMessage struct {
 	CreatedAt           string    `json:"created_at"`
@@ -13,4 +18,120 @@ type DirectMessage struct {
 	SenderID            int64     `json:"sender_id"`
 	SenderScreenName    string    `json:"sender_screen_name"`
 	Text                string    `json:"text"`
+}
+
+// DirectMessageService provides methods for accessing Twitter status API endpoints.
+type DirectMessageService struct {
+	baseSling *sling.Sling
+	sling     *sling.Sling
+}
+
+// newDirectMessageService returns a new StatusService.
+func newDirectMessageService(sling *sling.Sling) *DirectMessageService {
+	return &DirectMessageService{
+		baseSling: sling.New(),
+		sling:     sling.Path("direct_messages/"),
+	}
+}
+
+// DirectMessageShowParams are the parameters for DirectMessageService.Show
+type DirectMessageShowParams struct {
+	ID int64 `url:"id,omitempty"`
+}
+
+// Show returns the requested DirectMessage and all response messages.
+// https://dev.twitter.com/rest/reference/get/direct_messages/show
+func (s *DirectMessageService) Show(id int64) ([]DirectMessage, *http.Response, error) {
+	params := &StatusShowParams{ID: id}
+	dms := new([]DirectMessage)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("show.json").QueryStruct(params).Receive(dms, apiError)
+	return *dms, resp, relevantError(err, *apiError)
+}
+
+// DirectMessageGetParams are the parameters for DirectMessageService.Get
+type DirectMessageGetParams struct {
+	SinceID         int64 `url:"since_id,omitempty"`
+	MaxID           int64 `url:"max_id,omitempty"`
+	Count           int   `url:"count,omitempty"`
+	IncludeEntities *bool `url:"include_entities,omitempty"`
+	SkipStatus      *bool `url:"skip_status,omitempty"`
+}
+
+// Get returns the all the direct messages
+// https://dev.twitter.com/rest/reference/get/direct_messages
+func (s *DirectMessageService) Get(params *DirectMessageGetParams) ([]DirectMessage, *http.Response, error) {
+	if params == nil {
+		params = &DirectMessageGetParams{}
+	}
+	dms := new([]DirectMessage)
+	apiError := new(APIError)
+	resp, err := s.baseSling.New().Get("direct_messages.json").QueryStruct(params).Receive(dms, apiError)
+	return *dms, resp, relevantError(err, *apiError)
+}
+
+// DirectMessageSentParams are the parameters for DirectMessageService.Sent
+type DirectMessageSentParams struct {
+	SinceID         int64 `url:"since_id,omitempty"`
+	MaxID           int64 `url:"max_id,omitempty"`
+	Count           int   `url:"count,omitempty"`
+	Page            int   `url:"page,omitempty"`
+	IncludeEntities *bool `url:"include_entities,omitempty"`
+}
+
+// Sent returns the all the direct messages sent
+// https://dev.twitter.com/rest/reference/get/direct_messages/sent
+func (s *DirectMessageService) Sent(params *DirectMessageSentParams) ([]DirectMessage, *http.Response, error) {
+	if params == nil {
+		params = &DirectMessageSentParams{}
+	}
+	dms := new([]DirectMessage)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("sent.json").QueryStruct(params).Receive(dms, apiError)
+	return *dms, resp, relevantError(err, *apiError)
+}
+
+// DirectMessageNewParams are the parameters for DirectMessageService.New
+type DirectMessageNewParams struct {
+	UserID     int64  `url:"user_id,omitempty"`
+	ScreenName string `url:"screen_name,omitempty"`
+	Text       string `url:"text"`
+}
+
+// New creates a new direct message
+// https://dev.twitter.com/rest/reference/get/direct_messages/new
+func (s *DirectMessageService) New(params DirectMessageNewParams) (DirectMessage, *http.Response, error) {
+	dm := new(DirectMessage)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Post("new.json").BodyForm(params).Receive(dm, apiError)
+	return *dm, resp, relevantError(err, *apiError)
+}
+
+// SendToID sends a direct message by twitter user id
+func (s *DirectMessageService) SendToID(userID int64, text string) (DirectMessage, *http.Response, error) {
+	return s.New(DirectMessageNewParams{UserID: userID, Text: text})
+}
+
+// SendToScreenName sends a message by twitter user id
+func (s *DirectMessageService) SendToScreenName(screenName, text string) (DirectMessage, *http.Response, error) {
+	return s.New(DirectMessageNewParams{ScreenName: screenName, Text: text})
+}
+
+// DirectMessageDestroyParams are the parameters for DirectMessageService.Destroy
+type DirectMessageDestroyParams struct {
+	ID              int64 `url:"id,omitempty"`
+	IncludeEntities *bool `url:"include_entities,omitempty"`
+}
+
+// Destroy deletes a direct message
+// https://dev.twitter.com/rest/reference/get/direct_messages/new
+func (s *DirectMessageService) Destroy(id int64, params *DirectMessageDestroyParams) (DirectMessage, *http.Response, error) {
+	if params == nil {
+		params = &DirectMessageDestroyParams{}
+	}
+	params.ID = id
+	dm := new(DirectMessage)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Post("destroy.json").BodyForm(params).Receive(dm, apiError)
+	return *dm, resp, relevantError(err, *apiError)
 }

--- a/twitter/direct_messages_test.go
+++ b/twitter/direct_messages_test.go
@@ -1,0 +1,169 @@
+package twitter
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testDMID int64 = 240136858829479936
+var testDMIDStr = "240136858829479936"
+var testDMJSON = `{
+    "id": 240136858829479936,
+    "recipient": {
+        "screen_name": "s0c1alm3dia"
+    },
+    "sender": {
+        "screen_name": "theSeanCook"
+    },
+    "text": "booyakasha"
+}`
+var testDM = DirectMessage{ID: testDMID, Recipient: &User{ScreenName: "s0c1alm3dia"}, Sender: &User{ScreenName: "theSeanCook"}, Text: "booyakasha"}
+
+func TestDirectMessageService_Show(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/show.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"id": testDMIDStr}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[`+testDMJSON+`]`)
+	})
+
+	client := NewClient(httpClient)
+	dms, _, err := client.DirectMessages.Show(testDMID)
+	expected := []DirectMessage{testDM}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dms)
+}
+
+func TestDirectMessageService_Get(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"since_id": "589147592367431680", "count": "1"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[`+testDMJSON+`]`)
+	})
+
+	client := NewClient(httpClient)
+	params := &DirectMessageGetParams{SinceID: 589147592367431680, Count: 1}
+	dms, _, err := client.DirectMessages.Get(params)
+	expected := []DirectMessage{testDM}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dms)
+}
+
+func TestDirectMessageService_GetNilParams(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[`+testDMJSON+`]`)
+	})
+
+	client := NewClient(httpClient)
+	dms, _, err := client.DirectMessages.Get(nil)
+	expected := []DirectMessage{testDM}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dms)
+}
+
+func TestDirectMessageService_Sent(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/sent.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"since_id": "589147592367431680", "count": "1"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[`+testDMJSON+`]`)
+	})
+
+	client := NewClient(httpClient)
+	params := &DirectMessageSentParams{SinceID: 589147592367431680, Count: 1}
+	dms, _, err := client.DirectMessages.Sent(params)
+	expected := []DirectMessage{testDM}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dms)
+}
+
+func TestDirectMessageService_SentNilParams(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/sent.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[`+testDMJSON+`]`)
+	})
+
+	client := NewClient(httpClient)
+	dms, _, err := client.DirectMessages.Sent(nil)
+	expected := []DirectMessage{testDM}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dms)
+}
+
+func TestDirectMessageService_SendToID(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/new.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertPostForm(t, map[string]string{"user_id": "589147592367431680", "text": "booyakasha"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, testDMJSON)
+	})
+
+	client := NewClient(httpClient)
+	dm, _, err := client.DirectMessages.SendToID(589147592367431680, "booyakasha")
+	expected := testDM
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dm)
+}
+
+func TestDirectMessageService_SendToScreenName(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/new.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertPostForm(t, map[string]string{"screen_name": "s0c1alm3dia", "text": "booyakasha"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, testDMJSON)
+	})
+
+	client := NewClient(httpClient)
+	dm, _, err := client.DirectMessages.SendToScreenName("s0c1alm3dia", "booyakasha")
+	expected := testDM
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dm)
+}
+
+func TestDirectMessageService_Destroy(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/destroy.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertPostForm(t, map[string]string{"id": testDMIDStr}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, testDMJSON)
+	})
+
+	client := NewClient(httpClient)
+	dm, _, err := client.DirectMessages.Destroy(testDMID, nil)
+	expected := testDM
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dm)
+}

--- a/twitter/twitter.go
+++ b/twitter/twitter.go
@@ -12,25 +12,27 @@ const twitterAPI = "https://api.twitter.com/1.1/"
 type Client struct {
 	sling *sling.Sling
 	// Twitter API Services
-	Accounts  *AccountService
-	Statuses  *StatusService
-	Timelines *TimelineService
-	Users     *UserService
-	Followers *FollowerService
-	Streams   *StreamService
+	Accounts       *AccountService
+	Statuses       *StatusService
+	Timelines      *TimelineService
+	Users          *UserService
+	Followers      *FollowerService
+	DirectMessages *DirectMessageService
+	Streams        *StreamService
 }
 
 // NewClient returns a new Client.
 func NewClient(httpClient *http.Client) *Client {
 	base := sling.New().Client(httpClient).Base(twitterAPI)
 	return &Client{
-		sling:     base,
-		Accounts:  newAccountService(base.New()),
-		Statuses:  newStatusService(base.New()),
-		Timelines: newTimelineService(base.New()),
-		Users:     newUserService(base.New()),
-		Followers: newFollowerService(base.New()),
-		Streams:   newStreamService(httpClient, base.New()),
+		sling:          base,
+		Accounts:       newAccountService(base.New()),
+		Statuses:       newStatusService(base.New()),
+		Timelines:      newTimelineService(base.New()),
+		Users:          newUserService(base.New()),
+		Followers:      newFollowerService(base.New()),
+		DirectMessages: newDirectMessageService(base.New()),
+		Streams:        newStreamService(httpClient, base.New()),
 	}
 }
 


### PR DESCRIPTION
support for `/direct_messages` REST API:
- https://dev.twitter.com/rest/reference/get/direct_messages

Also included unit tests.