### PR TITLE
Fix documentation code formatting.

### DIFF
--- a/twitter/doc.go
+++ b/twitter/doc.go
@@ -35,8 +35,8 @@ has granted access, with OAuth1.
 
 	// OAuth1
 	import (
-  	"github.com/dghubble/go-twitter/twitter"
-  	"github.com/dghubble/oauth1"
+		"github.com/dghubble/go-twitter/twitter"
+		"github.com/dghubble/oauth1"
 	)
 
 	config := oauth1.NewConfig("consumerKey", "consumerSecret")
@@ -52,8 +52,8 @@ application auth.
 
 	// OAuth2
 	import (
-  	"github.com/dghubble/go-twitter/twitter"
-  	"golang.org/x/oauth2"
+		"github.com/dghubble/go-twitter/twitter"
+		"golang.org/x/oauth2"
 	)
 
 	config := &oauth2.Config{}


### PR DESCRIPTION
This fixes the documentation code formatting in the top section of https://godoc.org/github.com/dghubble/go-twitter/twitter.

Before:

![image](https://cloud.githubusercontent.com/assets/1924134/13212314/0cb51be0-d8f5-11e5-9559-4192e823bc6f.png)

After:

![image](https://cloud.githubusercontent.com/assets/1924134/13212310/0712e5b4-d8f5-11e5-8b9b-0fe07a01db0e.png)