### PR TITLE
remove explicit type pointing during array initialization

### DIFF
--- a/twitter/errors_test.go
+++ b/twitter/errors_test.go
@@ -9,7 +9,7 @@ import (
 
 var errAPI = APIError{
 	Errors: []ErrorDetail{
-		ErrorDetail{Message: "Status is a duplicate", Code: 187},
+		{Message: "Status is a duplicate", Code: 187},
 	},
 }
 var errHTTP = fmt.Errorf("unknown host")

--- a/twitter/favorites_test.go
+++ b/twitter/favorites_test.go
@@ -21,7 +21,7 @@ func TestFavoriteService_List(t *testing.T) {
 
 	client := NewClient(httpClient)
 	tweets, _, err := client.Favorites.List(&FavoriteListParams{UserID: 113419064, SinceID: 101492475, IncludeEntities: Bool(false)})
-	expected := []Tweet{Tweet{Text: "Gophercon talks!"}, Tweet{Text: "Why gophers are so adorable"}}
+	expected := []Tweet{{Text: "Gophercon talks!"}, {Text: "Why gophers are so adorable"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, tweets)
 }

--- a/twitter/followers_test.go
+++ b/twitter/followers_test.go
@@ -48,7 +48,7 @@ func TestFollowerService_List(t *testing.T) {
 		fmt.Fprintf(w, `{"users": [{"id": 123}], "next_cursor":1516837838944119498,"next_cursor_str":"1516837838944119498","previous_cursor":-1516924983503961435,"previous_cursor_str":"-1516924983503961435"}`)
 	})
 	expected := &Followers{
-		Users:             []User{User{ID: 123}},
+		Users:             []User{{ID: 123}},
 		NextCursor:        1516837838944119498,
 		NextCursorStr:     "1516837838944119498",
 		PreviousCursor:    -1516924983503961435,

--- a/twitter/search_test.go
+++ b/twitter/search_test.go
@@ -27,7 +27,7 @@ func TestSearchService_Tweets(t *testing.T) {
 	})
 	expected := &Search{
 		Statuses: []Tweet{
-			Tweet{ID: 781760642139250689},
+			{ID: 781760642139250689},
 		},
 		Metadata: &SearchMetadata{
 			Count:       1,

--- a/twitter/statuses_test.go
+++ b/twitter/statuses_test.go
@@ -53,7 +53,7 @@ func TestStatusService_Lookup(t *testing.T) {
 	client := NewClient(httpClient)
 	params := &StatusLookupParams{ID: []int64{20}, TrimUser: Bool(true)}
 	tweets, _, err := client.Statuses.Lookup([]int64{573893817000140800}, params)
-	expected := []Tweet{Tweet{ID: 20, Text: "just setting up my twttr"}, Tweet{ID: 573893817000140800, Text: "Don't get lost #PaxEast2015"}}
+	expected := []Tweet{{ID: 20, Text: "just setting up my twttr"}, {ID: 573893817000140800, Text: "Don't get lost #PaxEast2015"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, tweets)
 }
@@ -112,7 +112,7 @@ func TestStatusService_APIError(t *testing.T) {
 	_, _, err := client.Statuses.Update("very informative tweet", nil)
 	expected := APIError{
 		Errors: []ErrorDetail{
-			ErrorDetail{Message: "Status is a duplicate", Code: 187},
+			{Message: "Status is a duplicate", Code: 187},
 		},
 	}
 	if assert.Error(t, err) {
@@ -176,7 +176,7 @@ func TestStatusService_Retweets(t *testing.T) {
 	client := NewClient(httpClient)
 	params := &StatusRetweetsParams{Count: 2}
 	retweets, _, err := client.Statuses.Retweets(20, params)
-	expected := []Tweet{Tweet{Text: "RT @jack: just setting up my twttr"}, Tweet{Text: "RT @jack: just setting up my twttr"}}
+	expected := []Tweet{{Text: "RT @jack: just setting up my twttr"}, {Text: "RT @jack: just setting up my twttr"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, retweets)
 }

--- a/twitter/timelines_test.go
+++ b/twitter/timelines_test.go
@@ -21,7 +21,7 @@ func TestTimelineService_UserTimeline(t *testing.T) {
 
 	client := NewClient(httpClient)
 	tweets, _, err := client.Timelines.UserTimeline(&UserTimelineParams{UserID: 113419064, TrimUser: Bool(true), IncludeRetweets: Bool(false)})
-	expected := []Tweet{Tweet{Text: "Gophercon talks!"}, Tweet{Text: "Why gophers are so adorable"}}
+	expected := []Tweet{{Text: "Gophercon talks!"}, {Text: "Why gophers are so adorable"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, tweets)
 }
@@ -39,7 +39,7 @@ func TestTimelineService_HomeTimeline(t *testing.T) {
 
 	client := NewClient(httpClient)
 	tweets, _, err := client.Timelines.HomeTimeline(&HomeTimelineParams{SinceID: 589147592367431680, ExcludeReplies: Bool(false)})
-	expected := []Tweet{Tweet{Text: "Live on #Periscope"}, Tweet{Text: "Clickbait journalism"}, Tweet{Text: "Useful announcement"}}
+	expected := []Tweet{{Text: "Live on #Periscope"}, {Text: "Clickbait journalism"}, {Text: "Useful announcement"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, tweets)
 }
@@ -57,7 +57,7 @@ func TestTimelineService_MentionTimeline(t *testing.T) {
 
 	client := NewClient(httpClient)
 	tweets, _, err := client.Timelines.MentionTimeline(&MentionTimelineParams{Count: 20, IncludeEntities: Bool(false)})
-	expected := []Tweet{Tweet{Text: "@dghubble can I get verified?"}, Tweet{Text: "@dghubble why are gophers so great?"}}
+	expected := []Tweet{{Text: "@dghubble can I get verified?"}, {Text: "@dghubble why are gophers so great?"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, tweets)
 }
@@ -75,7 +75,7 @@ func TestTimelineService_RetweetsOfMeTimeline(t *testing.T) {
 
 	client := NewClient(httpClient)
 	tweets, _, err := client.Timelines.RetweetsOfMeTimeline(&RetweetsOfMeTimelineParams{TrimUser: Bool(false), IncludeUserEntities: Bool(false)})
-	expected := []Tweet{Tweet{Text: "RT Twitter UK edition"}, Tweet{Text: "RT Triply-replicated Gophers"}}
+	expected := []Tweet{{Text: "RT Twitter UK edition"}, {Text: "RT Triply-replicated Gophers"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, tweets)
 }

--- a/twitter/users_test.go
+++ b/twitter/users_test.go
@@ -39,7 +39,7 @@ func TestUserService_LookupWithIds(t *testing.T) {
 
 	client := NewClient(httpClient)
 	users, _, err := client.Users.Lookup(&UserLookupParams{UserID: []int64{113419064, 623265148}})
-	expected := []User{User{ScreenName: "golang"}, User{ScreenName: "dghubble"}}
+	expected := []User{{ScreenName: "golang"}, {ScreenName: "dghubble"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, users)
 }
@@ -57,7 +57,7 @@ func TestUserService_LookupWithScreenNames(t *testing.T) {
 
 	client := NewClient(httpClient)
 	users, _, err := client.Users.Lookup(&UserLookupParams{ScreenName: []string{"foo", "bar"}})
-	expected := []User{User{Name: "Foo"}, User{Name: "Bar"}}
+	expected := []User{{Name: "Foo"}, {Name: "Bar"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, users)
 }
@@ -75,7 +75,7 @@ func TestUserService_Search(t *testing.T) {
 
 	client := NewClient(httpClient)
 	users, _, err := client.Users.Search("news", &UserSearchParams{Query: "override me", Count: 11})
-	expected := []User{User{Name: "BBC"}, User{Name: "BBC Breaking News"}}
+	expected := []User{{Name: "BBC"}, {Name: "BBC Breaking News"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, users)
 }


### PR DESCRIPTION
Hi, 
This PR contains some enhancements for array initialization.
You can skip type of the object during array initialization.