### PR TITLE
Ignore Tweet "contributors" field

### DIFF
--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -11,7 +11,7 @@ import (
 // https://dev.twitter.com/overview/api/tweets
 // Unused or deprecated fields not provided: Geo, Annotations
 type Tweet struct {
-	Contributors         []Contributor          `json:"contributors"`
+	Contributors         []Contributor          `json:"-"`
 	Coordinates          *Coordinates           `json:"coordinates"`
 	CreatedAt            string                 `json:"created_at"`
 	CurrentUserRetweet   *TweetIdentifier       `json:"current_user_retweet"`


### PR DESCRIPTION
* Ignore the contributors field when decoding. Inconsistent formats across APIs cause decoding errors

Fixes #28 