### PR TITLE
Add client.Friendships.Destroy

### DIFF
--- a/twitter/friendships.go
+++ b/twitter/friendships.go
@@ -1,0 +1,38 @@
+package twitter
+
+import (
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// FriendshipService provides methods for accessing
+// Twitter friendship API endpoints.
+type FriendshipService struct {
+	sling *sling.Sling
+}
+
+// newFriendshipService returns a new FriendshipService.
+func newFriendshipService(sling *sling.Sling) *FriendshipService {
+	return &FriendshipService{
+		sling: sling.Path("friendships/"),
+	}
+}
+
+// FriendshipDestroyParams are the parameters for FriendshipService.Destroy
+type FriendshipDestroyParams struct {
+	ScreenName string `url:"screen_name,omitempty"`
+	UserID     int64  `url:"user_id,omitempty"`
+}
+
+// Destroy deletes the Friendship for the given user id or screen name and
+// returns friend if successful.
+// Requires a user auth context.
+// https://dev.twitter.com/rest/reference/post/friendships/destroy
+func (s *FriendshipService) Destroy(params *FriendshipDestroyParams) (*User, *http.Response, error) {
+	user := new(User)
+	apiError := new(APIError)
+	path := "destroy.json"
+	resp, err := s.sling.New().QueryStruct(params).Post(path).Receive(user, apiError)
+	return user, resp, relevantError(err, *apiError)
+}

--- a/twitter/friendships_test.go
+++ b/twitter/friendships_test.go
@@ -1,0 +1,82 @@
+package twitter
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFriendshipService_DestroyHandlesUserIDParam(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/friendships/destroy.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertQuery(t, map[string]string{"user_id": "123"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id": 123, "screen_name": "croaky"}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &FriendshipDestroyParams{UserID: 123}
+	user, _, err := client.Friendships.Destroy(params)
+	expected := &User{ID: 123, ScreenName: "croaky"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, user)
+}
+
+func TestFriendshipService_DestroyHandlesScreenNameParam(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/friendships/destroy.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertQuery(t, map[string]string{"screen_name": "croaky"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id": 123, "screen_name": "croaky"}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &FriendshipDestroyParams{ScreenName: "croaky"}
+	tweet, _, err := client.Friendships.Destroy(params)
+	expected := &User{ID: 123, ScreenName: "croaky"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, tweet)
+}
+
+func TestFriendshipService_DestroyHandlesNilParams(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/friendships/destroy.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertQuery(t, map[string]string{}, r)
+	})
+
+	client := NewClient(httpClient)
+	client.Friendships.Destroy(nil)
+}
+
+func TestFriendshipService_APIError(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/friendships/destroy.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		fmt.Fprintf(w, `{"errors": [{"message": "Sorry, that page does not exist.", "code": 34}]}`)
+	})
+
+	client := NewClient(httpClient)
+	_, _, err := client.Friendships.Destroy(nil)
+	expected := APIError{
+		Errors: []ErrorDetail{
+			ErrorDetail{Message: "Sorry, that page does not exist.", Code: 34},
+		},
+	}
+	if assert.Error(t, err) {
+		assert.Equal(t, expected, err)
+	}
+}

--- a/twitter/twitter.go
+++ b/twitter/twitter.go
@@ -17,6 +17,7 @@ type Client struct {
 	Favorites      *FavoriteService
 	Followers      *FollowerService
 	Friends        *FriendService
+	Friendships    *FriendshipService
 	Search         *SearchService
 	Statuses       *StatusService
 	Streams        *StreamService
@@ -34,6 +35,7 @@ func NewClient(httpClient *http.Client) *Client {
 		Favorites:      newFavoriteService(base.New()),
 		Followers:      newFollowerService(base.New()),
 		Friends:        newFriendService(base.New()),
+		Friendships:    newFriendshipService(base.New()),
 		Search:         newSearchService(base.New()),
 		Statuses:       newStatusService(base.New()),
 		Streams:        newStreamService(httpClient, base.New()),


### PR DESCRIPTION
Enable go-twitter programs to allow auth'ed users to delete their
Twitter "friends" (other users they follow) by implementing:

https://dev.twitter.com/rest/reference/post/friendships/destroy

Follow patterns established by `StatusService.Destroy` and its tests.