### PR TITLE
Add FullText and DisplayTextRange for Compatibility and Extended modes

### DIFF
--- a/examples/app-auth.go
+++ b/examples/app-auth.go
@@ -45,7 +45,7 @@ func main() {
 	fmt.Printf("STATUSES SHOW:\n%+v\n", tweet)
 
 	// statuses lookup
-	statusLookupParams := &twitter.StatusLookupParams{ID: []int64{20}}
+	statusLookupParams := &twitter.StatusLookupParams{ID: []int64{20}, TweetMode: "extended"}
 	tweets, _, _ := client.Statuses.Lookup([]int64{573893817000140800}, statusLookupParams)
 	fmt.Printf("STATUSES LOOKUP:\n%+v\n", tweets)
 

--- a/examples/app-auth.go
+++ b/examples/app-auth.go
@@ -61,10 +61,11 @@ func main() {
 
 	// search tweets
 	searchTweetParams := &twitter.SearchTweetParams{
-		Query: "happy birthday",
-		Count: 3,
+		Query:     "happy birthday",
+		TweetMode: "extended",
+		Count:     3,
 	}
 	search, _, _ := client.Search.Tweets(searchTweetParams)
 	fmt.Printf("SEARCH TWEETS:\n%+v\n", search)
-	fmt.Printf("SEARCH METADATA:\n%+v\n", search.SearchMetadata)
+	fmt.Printf("SEARCH METADATA:\n%+v\n", search.Metadata)
 }

--- a/examples/user-auth.go
+++ b/examples/user-auth.go
@@ -41,17 +41,26 @@ func main() {
 	fmt.Printf("User's ACCOUNT:\n%+v\n", user)
 
 	// Home Timeline
-	homeTimelineParams := &twitter.HomeTimelineParams{Count: 2}
+	homeTimelineParams := &twitter.HomeTimelineParams{
+		Count:     2,
+		TweetMode: "extended",
+	}
 	tweets, _, _ := client.Timelines.HomeTimeline(homeTimelineParams)
 	fmt.Printf("User's HOME TIMELINE:\n%+v\n", tweets)
 
 	// Mention Timeline
-	mentionTimelineParams := &twitter.MentionTimelineParams{Count: 2}
+	mentionTimelineParams := &twitter.MentionTimelineParams{
+		Count:     2,
+		TweetMode: "extended",
+	}
 	tweets, _, _ = client.Timelines.MentionTimeline(mentionTimelineParams)
 	fmt.Printf("User's MENTION TIMELINE:\n%+v\n", tweets)
 
 	// Retweets of Me Timeline
-	retweetTimelineParams := &twitter.RetweetsOfMeTimelineParams{Count: 2}
+	retweetTimelineParams := &twitter.RetweetsOfMeTimelineParams{
+		Count:     2,
+		TweetMode: "extended",
+	}
 	tweets, _, _ = client.Timelines.RetweetsOfMeTimeline(retweetTimelineParams)
 	fmt.Printf("User's 'RETWEETS OF ME' TIMELINE:\n%+v\n", tweets)
 

--- a/twitter/favorites.go
+++ b/twitter/favorites.go
@@ -29,6 +29,7 @@ type FavoriteListParams struct {
 	SinceID         int64  `url:"since_id,omitempty"`
 	MaxID           int64  `url:"max_id,omitempty"`
 	IncludeEntities *bool  `url:"include_entities,omitempty"`
+	TweetMode       string `url:"tweet_mode,omitempty"`
 }
 
 // List returns liked Tweets from the specified user.

--- a/twitter/search.go
+++ b/twitter/search.go
@@ -49,6 +49,7 @@ type SearchTweetParams struct {
 	MaxID           int64  `url:"max_id,omitempty"`
 	Until           string `url:"until,omitempty"`
 	IncludeEntities *bool  `url:"include_entities,omitempty"`
+	TweetMode       string `url:"tweet_mode,omitempty"`
 }
 
 // Tweets returns a collection of Tweets matching a search query.

--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -105,10 +105,11 @@ func newStatusService(sling *sling.Sling) *StatusService {
 
 // StatusShowParams are the parameters for StatusService.Show
 type StatusShowParams struct {
-	ID               int64 `url:"id,omitempty"`
-	TrimUser         *bool `url:"trim_user,omitempty"`
-	IncludeMyRetweet *bool `url:"include_my_retweet,omitempty"`
-	IncludeEntities  *bool `url:"include_entities,omitempty"`
+	ID               int64  `url:"id,omitempty"`
+	TrimUser         *bool  `url:"trim_user,omitempty"`
+	IncludeMyRetweet *bool  `url:"include_my_retweet,omitempty"`
+	IncludeEntities  *bool  `url:"include_entities,omitempty"`
+	TweetMode        string `url:"tweet_mode,omitempty"`
 }
 
 // Show returns the requested Tweet.
@@ -130,6 +131,7 @@ type StatusLookupParams struct {
 	TrimUser        *bool   `url:"trim_user,omitempty"`
 	IncludeEntities *bool   `url:"include_entities,omitempty"`
 	Map             *bool   `url:"map,omitempty"`
+	TweetMode       string  `url:"tweet_mode,omitempty"`
 }
 
 // Lookup returns the requested Tweets as a slice. Combines ids from the
@@ -157,6 +159,7 @@ type StatusUpdateParams struct {
 	DisplayCoordinates *bool    `url:"display_coordinates,omitempty"`
 	TrimUser           *bool    `url:"trim_user,omitempty"`
 	MediaIds           []int64  `url:"media_ids,omitempty,comma"`
+	TweetMode          string   `url:"tweet_mode,omitempty"`
 }
 
 // Update updates the user's status, also known as Tweeting.
@@ -175,8 +178,9 @@ func (s *StatusService) Update(status string, params *StatusUpdateParams) (*Twee
 
 // StatusRetweetParams are the parameters for StatusService.Retweet
 type StatusRetweetParams struct {
-	ID       int64 `url:"id,omitempty"`
-	TrimUser *bool `url:"trim_user,omitempty"`
+	ID        int64  `url:"id,omitempty"`
+	TrimUser  *bool  `url:"trim_user,omitempty"`
+	TweetMode string `url:"tweet_mode,omitempty"`
 }
 
 // Retweet retweets the Tweet with the given id and returns the original Tweet
@@ -197,8 +201,9 @@ func (s *StatusService) Retweet(id int64, params *StatusRetweetParams) (*Tweet, 
 
 // StatusUnretweetParams are the parameters for StatusService.Unretweet
 type StatusUnretweetParams struct {
-	ID       int64 `url:"id,omitempty"`
-	TrimUser *bool `url:"trim_user,omitempty"`
+	ID        int64  `url:"id,omitempty"`
+	TrimUser  *bool  `url:"trim_user,omitempty"`
+	TweetMode string `url:"tweet_mode,omitempty"`
 }
 
 // Unretweet unretweets the Tweet with the given id and returns the original Tweet.
@@ -218,9 +223,10 @@ func (s *StatusService) Unretweet(id int64, params *StatusUnretweetParams) (*Twe
 
 // StatusRetweetsParams are the parameters for StatusService.Retweets
 type StatusRetweetsParams struct {
-	ID       int64 `url:"id,omitempty"`
-	Count    int   `url:"count,omitempty"`
-	TrimUser *bool `url:"trim_user,omitempty"`
+	ID        int64  `url:"id,omitempty"`
+	Count     int    `url:"count,omitempty"`
+	TrimUser  *bool  `url:"trim_user,omitempty"`
+	TweetMode string `url:"tweet_mode,omitempty"`
 }
 
 // Retweets returns the most recent retweets of the Tweet with the given id.
@@ -239,8 +245,9 @@ func (s *StatusService) Retweets(id int64, params *StatusRetweetsParams) ([]Twee
 
 // StatusDestroyParams are the parameters for StatusService.Destroy
 type StatusDestroyParams struct {
-	ID       int64 `url:"id,omitempty"`
-	TrimUser *bool `url:"trim_user,omitempty"`
+	ID        int64  `url:"id,omitempty"`
+	TrimUser  *bool  `url:"trim_user,omitempty"`
+	TweetMode string `url:"tweet_mode,omitempty"`
 }
 
 // Destroy deletes the Tweet with the given id and returns it if successful.

--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -33,6 +33,7 @@ type Tweet struct {
 	Source               string                 `json:"source"`
 	Scopes               map[string]interface{} `json:"scopes"`
 	Text                 string                 `json:"text"`
+	FullText             string                 `json:"full_text"`
 	Place                *Place                 `json:"place"`
 	Truncated            bool                   `json:"truncated"`
 	User                 *User                  `json:"user"`

--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -34,6 +34,7 @@ type Tweet struct {
 	Scopes               map[string]interface{} `json:"scopes"`
 	Text                 string                 `json:"text"`
 	FullText             string                 `json:"full_text"`
+	DisplayTextRange     Indices                `json:"display_text_range"`
 	Place                *Place                 `json:"place"`
 	Truncated            bool                   `json:"truncated"`
 	User                 *User                  `json:"user"`
@@ -41,9 +42,18 @@ type Tweet struct {
 	WithheldInCountries  []string               `json:"withheld_in_countries"`
 	WithheldScope        string                 `json:"withheld_scope"`
 	ExtendedEntities     *ExtendedEntity        `json:"extended_entities"`
+	ExtendedTweet        *ExtendedTweet         `json:"extended_tweet"`
 	QuotedStatusID       int64                  `json:"quoted_status_id"`
 	QuotedStatusIDStr    string                 `json:"quoted_status_id_str"`
 	QuotedStatus         *Tweet                 `json:"quoted_status"`
+}
+
+// ExtendedTweet represents fields embedded in extended Tweets when served in
+// compatibility mode (default).
+// https://dev.twitter.com/overview/api/upcoming-changes-to-tweets
+type ExtendedTweet struct {
+	FullText         string  `json:"full_text"`
+	DisplayTextRange Indices `json:"display_text_range"`
 }
 
 // Place represents a Twitter Place / Location

--- a/twitter/timelines.go
+++ b/twitter/timelines.go
@@ -29,6 +29,7 @@ type UserTimelineParams struct {
 	TrimUser        *bool  `url:"trim_user,omitempty"`
 	ExcludeReplies  *bool  `url:"exclude_replies,omitempty"`
 	IncludeRetweets *bool  `url:"include_rts,omitempty"`
+	TweetMode       string `url:"tweet_mode,omitempty"`
 }
 
 // UserTimeline returns recent Tweets from the specified user.
@@ -42,13 +43,14 @@ func (s *TimelineService) UserTimeline(params *UserTimelineParams) ([]Tweet, *ht
 
 // HomeTimelineParams are the parameters for TimelineService.HomeTimeline.
 type HomeTimelineParams struct {
-	Count              int   `url:"count,omitempty"`
-	SinceID            int64 `url:"since_id,omitempty"`
-	MaxID              int64 `url:"max_id,omitempty"`
-	TrimUser           *bool `url:"trim_user,omitempty"`
-	ExcludeReplies     *bool `url:"exclude_replies,omitempty"`
-	ContributorDetails *bool `url:"contributor_details,omitempty"`
-	IncludeEntities    *bool `url:"include_entities,omitempty"`
+	Count              int    `url:"count,omitempty"`
+	SinceID            int64  `url:"since_id,omitempty"`
+	MaxID              int64  `url:"max_id,omitempty"`
+	TrimUser           *bool  `url:"trim_user,omitempty"`
+	ExcludeReplies     *bool  `url:"exclude_replies,omitempty"`
+	ContributorDetails *bool  `url:"contributor_details,omitempty"`
+	IncludeEntities    *bool  `url:"include_entities,omitempty"`
+	TweetMode          string `url:"tweet_mode,omitempty"`
 }
 
 // HomeTimeline returns recent Tweets and retweets from the user and those
@@ -64,12 +66,13 @@ func (s *TimelineService) HomeTimeline(params *HomeTimelineParams) ([]Tweet, *ht
 
 // MentionTimelineParams are the parameters for TimelineService.MentionTimeline.
 type MentionTimelineParams struct {
-	Count              int   `url:"count,omitempty"`
-	SinceID            int64 `url:"since_id,omitempty"`
-	MaxID              int64 `url:"max_id,omitempty"`
-	TrimUser           *bool `url:"trim_user,omitempty"`
-	ContributorDetails *bool `url:"contributor_details,omitempty"`
-	IncludeEntities    *bool `url:"include_entities,omitempty"`
+	Count              int    `url:"count,omitempty"`
+	SinceID            int64  `url:"since_id,omitempty"`
+	MaxID              int64  `url:"max_id,omitempty"`
+	TrimUser           *bool  `url:"trim_user,omitempty"`
+	ContributorDetails *bool  `url:"contributor_details,omitempty"`
+	IncludeEntities    *bool  `url:"include_entities,omitempty"`
+	TweetMode          string `url:"tweet_mode,omitempty"`
 }
 
 // MentionTimeline returns recent Tweet mentions of the authenticated user.
@@ -85,12 +88,13 @@ func (s *TimelineService) MentionTimeline(params *MentionTimelineParams) ([]Twee
 // RetweetsOfMeTimelineParams are the parameters for
 // TimelineService.RetweetsOfMeTimeline.
 type RetweetsOfMeTimelineParams struct {
-	Count               int   `url:"count,omitempty"`
-	SinceID             int64 `url:"since_id,omitempty"`
-	MaxID               int64 `url:"max_id,omitempty"`
-	TrimUser            *bool `url:"trim_user,omitempty"`
-	IncludeEntities     *bool `url:"include_entities,omitempty"`
-	IncludeUserEntities *bool `url:"include_user_entities"`
+	Count               int    `url:"count,omitempty"`
+	SinceID             int64  `url:"since_id,omitempty"`
+	MaxID               int64  `url:"max_id,omitempty"`
+	TrimUser            *bool  `url:"trim_user,omitempty"`
+	IncludeEntities     *bool  `url:"include_entities,omitempty"`
+	IncludeUserEntities *bool  `url:"include_user_entities"`
+	TweetMode           string `url:"tweet_mode,omitempty"`
 }
 
 // RetweetsOfMeTimeline returns the most recent Tweets by the authenticated


### PR DESCRIPTION
Adds Tweet fields `FullText` and `DisplayTextRange` which are populated for extended Tweets in extended mode and adds an embedded `ExtendedTweet` which is populated for extended Tweets in compatability mode.

Request Parameters:

* Add TweetMode to Search (includes #60, thanks)
* Add TweetMode to Statuses endpoints
* Add TweetMode to Timeline endpoints
* Add TweetMode to Favorites endpoints

Its not entirely clear which endpoints support the mode parameter yet, as upstream says:

> Any REST API endpoints that return Tweets will accept a new tweet_mode request parameter. Valid request values are compat and extended, which give compatibility mode and extended mode, respectively.

In particular, the new mode does not yet seem to work on streaming endpoints.

cc @steve-winter @ljfio @jwmurray
Closes #56 