### PR TITLE
Add support for site stream messages

### DIFF
--- a/twitter/demux.go
+++ b/twitter/demux.go
@@ -11,37 +11,47 @@ type Demux interface {
 // SwitchDemux receives messages and uses a type switch to send each typed
 // message to a handler function.
 type SwitchDemux struct {
-	All              func(message interface{})
-	Tweet            func(tweet *Tweet)
-	DM               func(dm *DirectMessage)
-	StatusDeletion   func(deletion *StatusDeletion)
-	LocationDeletion func(LocationDeletion *LocationDeletion)
-	StreamLimit      func(limit *StreamLimit)
-	StatusWithheld   func(statusWithheld *StatusWithheld)
-	UserWithheld     func(userWithheld *UserWithheld)
-	StreamDisconnect func(disconnect *StreamDisconnect)
-	Warning          func(warning *StallWarning)
-	FriendsList      func(friendsList *FriendsList)
-	Event            func(event *Event)
-	Other            func(message interface{})
+	All                     func(message interface{})
+	Tweet                   func(tweet *Tweet)
+	DM                      func(dm *DirectMessage)
+	StatusDeletion          func(deletion *StatusDeletion)
+	LocationDeletion        func(LocationDeletion *LocationDeletion)
+	StreamLimit             func(limit *StreamLimit)
+	StatusWithheld          func(statusWithheld *StatusWithheld)
+	UserWithheld            func(userWithheld *UserWithheld)
+	StreamDisconnect        func(disconnect *StreamDisconnect)
+	Warning                 func(warning *StallWarning)
+	FriendsList             func(friendsList *FriendsList)
+	Event                   func(event *Event)
+	SiteStreamControl       func(control *SiteStreamControl)
+	SiteStreamTweet         func(tweet *SiteStreamTweet)
+	SiteStreamFriendsList   func(friendsList *SiteStreamFriendsList)
+	SiteStreamDirectMessage func(dm *SiteStreamDirectMessage)
+	StreamRequestError      func(r *StreamRequestError)
+	Other                   func(message interface{})
 }
 
 // NewSwitchDemux returns a new SwitchMux which has NoOp handler functions.
 func NewSwitchDemux() SwitchDemux {
 	return SwitchDemux{
-		All:              func(message interface{}) {},
-		Tweet:            func(tweet *Tweet) {},
-		DM:               func(dm *DirectMessage) {},
-		StatusDeletion:   func(deletion *StatusDeletion) {},
-		LocationDeletion: func(LocationDeletion *LocationDeletion) {},
-		StreamLimit:      func(limit *StreamLimit) {},
-		StatusWithheld:   func(statusWithheld *StatusWithheld) {},
-		UserWithheld:     func(userWithheld *UserWithheld) {},
-		StreamDisconnect: func(disconnect *StreamDisconnect) {},
-		Warning:          func(warning *StallWarning) {},
-		FriendsList:      func(friendsList *FriendsList) {},
-		Event:            func(event *Event) {},
-		Other:            func(message interface{}) {},
+		All:                     func(message interface{}) {},
+		Tweet:                   func(tweet *Tweet) {},
+		DM:                      func(dm *DirectMessage) {},
+		StatusDeletion:          func(deletion *StatusDeletion) {},
+		LocationDeletion:        func(LocationDeletion *LocationDeletion) {},
+		StreamLimit:             func(limit *StreamLimit) {},
+		StatusWithheld:          func(statusWithheld *StatusWithheld) {},
+		UserWithheld:            func(userWithheld *UserWithheld) {},
+		StreamDisconnect:        func(disconnect *StreamDisconnect) {},
+		Warning:                 func(warning *StallWarning) {},
+		FriendsList:             func(friendsList *FriendsList) {},
+		Event:                   func(event *Event) {},
+		SiteStreamControl:       func(control *SiteStreamControl) {},
+		SiteStreamTweet:         func(tweet *SiteStreamTweet) {},
+		SiteStreamFriendsList:   func(friendsList *SiteStreamFriendsList) {},
+		SiteStreamDirectMessage: func(dm *SiteStreamDirectMessage) {},
+		StreamRequestError:      func(r *StreamRequestError) {},
+		Other:                   func(message interface{}) {},
 	}
 }
 
@@ -73,6 +83,16 @@ func (d SwitchDemux) Handle(message interface{}) {
 		d.FriendsList(msg)
 	case *Event:
 		d.Event(msg)
+	case *SiteStreamTweet:
+		d.SiteStreamTweet(msg)
+	case *SiteStreamFriendsList:
+		d.SiteStreamFriendsList(msg)
+	case *SiteStreamDirectMessage:
+		d.SiteStreamDirectMessage(msg)
+	case *SiteStreamControl:
+		d.SiteStreamControl(msg)
+	case *StreamRequestError:
+		d.StreamRequestError(msg)
 	default:
 		d.Other(msg)
 	}

--- a/twitter/entities.go
+++ b/twitter/entities.go
@@ -1,5 +1,22 @@
 package twitter
 
+// SiteStreamWrapper struct
+type SiteStreamWrapper struct {
+	ForUser int64                    `json:"for_user"`
+	Message SiteStreamWrapperMessage `json:"message"`
+}
+
+// SiteStreamWrapperMessage can be one of many kinds of objects
+type SiteStreamWrapperMessage struct {
+	FriendsList
+	Tweet
+}
+
+// Control message sent over SiteStreams
+type Control struct {
+	ControlURI string `json:"control_uri"`
+}
+
 // Entities represent metadata and context info parsed from Twitter components.
 // https://dev.twitter.com/overview/api/entities
 // TODO: symbols

--- a/twitter/entities.go
+++ b/twitter/entities.go
@@ -1,5 +1,11 @@
 package twitter
 
+// SiteStream message wrapper
+type SiteStream struct {
+	ForUser int64 `json:"for_user"`
+	Message map[string]interface{}
+}
+
 // SiteStreamTweet struct
 type SiteStreamTweet struct {
 	ForUser int64 `json:"for_user"`

--- a/twitter/entities.go
+++ b/twitter/entities.go
@@ -1,20 +1,28 @@
 package twitter
 
-// SiteStreamWrapper struct
-type SiteStreamWrapper struct {
-	ForUser int64                    `json:"for_user"`
-	Message SiteStreamWrapperMessage `json:"message"`
+// SiteStreamTweet struct
+type SiteStreamTweet struct {
+	ForUser int64 `json:"for_user"`
+	Message Tweet
 }
 
-// SiteStreamWrapperMessage can be one of many kinds of objects
-type SiteStreamWrapperMessage struct {
-	FriendsList
-	Tweet
+// SiteStreamFriendsList struct
+type SiteStreamFriendsList struct {
+	ForUser int64 `json:"for_user"`
+	Message FriendsList
 }
 
-// Control message sent over SiteStreams
-type Control struct {
-	ControlURI string `json:"control_uri"`
+// SiteStreamDirectMessage struct
+type SiteStreamDirectMessage struct {
+	ForUser int64 `json:"for_user"`
+	Message DirectMessage
+}
+
+// SiteStreamControl message
+type SiteStreamControl struct {
+	Control struct {
+		ControlURI string `json:"control_uri"`
+	}
 }
 
 // Entities represent metadata and context info parsed from Twitter components.

--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -17,7 +17,6 @@ type Tweet struct {
 	Entities             *Entities              `json:"entities"`
 	FavoriteCount        int                    `json:"favorite_count"`
 	Favorited            bool                   `json:"favorited"`
-	DisplayTextRange     *Indices               `json:"display_text_range"`
 	FilterLevel          string                 `json:"filter_level"`
 	ID                   int64                  `json:"id"`
 	IDStr                string                 `json:"id_str"`

--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -17,6 +17,7 @@ type Tweet struct {
 	Entities             *Entities              `json:"entities"`
 	FavoriteCount        int                    `json:"favorite_count"`
 	Favorited            bool                   `json:"favorited"`
+	DisplayTextRange     *Indices               `json:"display_text_range"`
 	FilterLevel          string                 `json:"filter_level"`
 	ID                   int64                  `json:"id"`
 	IDStr                string                 `json:"id_str"`
@@ -43,6 +44,7 @@ type Tweet struct {
 	QuotedStatusID       int64                  `json:"quoted_status_id"`
 	QuotedStatusIDStr    string                 `json:"quoted_status_id_str"`
 	QuotedStatus         *Tweet                 `json:"quoted_status"`
+	IsQuoteStatus        bool                   `json:"is_quote_status"`
 }
 
 // Place represents a Twitter Place / Location

--- a/twitter/streams.go
+++ b/twitter/streams.go
@@ -351,23 +351,44 @@ func decodeMessage(token []byte, data map[string]interface{}) interface{} {
 		json.Unmarshal(token, &control)
 		return &control
 	} else if hasPath(data, "for_user") {
+
 		// Site Stream messages could be one of several objects
 		var err error
-		siteStreamFriendsList := new(SiteStreamFriendsList)
-		err = json.Unmarshal(token, siteStreamFriendsList)
-		if err == nil {
-			return siteStreamFriendsList
+		var siteStream SiteStream
+		err = json.Unmarshal(token, &siteStream)
+		if err != nil {
+			return data
 		}
-		siteStreamTweet := new(SiteStreamTweet)
-		err = json.Unmarshal(token, siteStreamTweet)
-		if err == nil {
-			return siteStreamTweet
+
+		// FriendsList
+		if hasPath(siteStream.Message, "friends") {
+			siteStreamFriendsList := new(SiteStreamFriendsList)
+			err = json.Unmarshal(token, siteStreamFriendsList)
+			if err == nil {
+				return siteStreamFriendsList
+			}
 		}
-		siteStreamDirectMessage := new(SiteStreamDirectMessage)
-		err = json.Unmarshal(token, siteStreamDirectMessage)
-		if err == nil {
-			return siteStreamDirectMessage
+
+		// Tweet
+		if hasPath(siteStream.Message, "retweet_count") {
+			siteStreamTweet := new(SiteStreamTweet)
+			err = json.Unmarshal(token, siteStreamTweet)
+			if err == nil {
+				return siteStreamTweet
+			}
 		}
+
+		// DM
+		if hasPath(siteStream.Message, "sender_id") {
+			siteStreamDirectMessage := new(SiteStreamDirectMessage)
+			err = json.Unmarshal(token, siteStreamDirectMessage)
+			if err == nil {
+				return siteStreamDirectMessage
+			}
+		}
+
+		// TODO other types here
+
 	}
 
 	// message type unknown, return the data map[string]interface{}

--- a/twitter/streams_test.go
+++ b/twitter/streams_test.go
@@ -123,7 +123,7 @@ func TestStream_Filter(t *testing.T) {
 	for message := range stream.Messages {
 		demux.Handle(message)
 	}
-	expectedCounts := &counter{all: 2, other: 2}
+	expectedCounts := &counter{all: 3, other: 2}
 	assert.Equal(t, expectedCounts, counts)
 }
 
@@ -163,7 +163,7 @@ func TestStream_Sample(t *testing.T) {
 	for message := range stream.Messages {
 		demux.Handle(message)
 	}
-	expectedCounts := &counter{all: 2, other: 2}
+	expectedCounts := &counter{all: 3, other: 2}
 	assert.Equal(t, expectedCounts, counts)
 }
 
@@ -201,7 +201,7 @@ func TestStream_User(t *testing.T) {
 	for message := range stream.Messages {
 		demux.Handle(message)
 	}
-	expectedCounts := &counter{all: 1, friendsList: 1}
+	expectedCounts := &counter{all: 2, friendsList: 1}
 	assert.Equal(t, expectedCounts, counts)
 }
 
@@ -241,7 +241,7 @@ func TestStream_Site(t *testing.T) {
 	for message := range stream.Messages {
 		demux.Handle(message)
 	}
-	expectedCounts := &counter{all: 2, other: 2}
+	expectedCounts := &counter{all: 3, other: 2}
 	assert.Equal(t, expectedCounts, counts)
 }
 
@@ -281,7 +281,7 @@ func TestStream_PublicFirehose(t *testing.T) {
 	for message := range stream.Messages {
 		demux.Handle(message)
 	}
-	expectedCounts := &counter{all: 2, other: 2}
+	expectedCounts := &counter{all: 3, other: 2}
 	assert.Equal(t, expectedCounts, counts)
 }
 


### PR DESCRIPTION
Fixes #69 and #66 by allowing the library to process `{"for_user":...}` type wrappers around Tweet and FriendsList structs and supporting the new `{"control":...}` entity.