### PR TITLE
Fix StreamService.User(): parse very long friend ID lists properly

### DIFF
--- a/twitter/stream_utils.go
+++ b/twitter/stream_utils.go
@@ -1,7 +1,6 @@
 package twitter
 
 import (
-	"strings"
 	"time"
 )
 
@@ -25,32 +24,4 @@ func sleepOrDone(d time.Duration, done <-chan struct{}) {
 	case <-done:
 		return
 	}
-}
-
-// scanLines is a split function for a Scanner that returns each line of text
-// stripped of the end-of-line marker "\r\n" used by Twitter Streaming APIs.
-// This differs from the bufio.ScanLines split function which considers the
-// '\r' optional.
-// https://dev.twitter.com/streaming/overview/processing
-func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	if atEOF && len(data) == 0 {
-		return 0, nil, nil
-	}
-	if i := strings.Index(string(data), "\r\n"); i >= 0 {
-		// We have a full '\r\n' terminated line.
-		return i + 2, data[0:i], nil
-	}
-	// If we're at EOF, we have a final, non-terminated line. Return it.
-	if atEOF {
-		return len(data), dropCR(data), nil
-	}
-	// Request more data.
-	return 0, nil, nil
-}
-
-func dropCR(data []byte) []byte {
-	if len(data) > 0 && data[len(data)-1] == '\n' {
-		return data[0 : len(data)-1]
-	}
-	return data
 }

--- a/twitter/stream_utils.go
+++ b/twitter/stream_utils.go
@@ -1,6 +1,9 @@
 package twitter
 
 import (
+	"bufio"
+	"bytes"
+	"io"
 	"time"
 )
 
@@ -24,4 +27,67 @@ func sleepOrDone(d time.Duration, done <-chan struct{}) {
 	case <-done:
 		return
 	}
+}
+
+// streamResponseBodyReader is a buffered reader for Twitter stream response
+// body. It can scan the arbitrary length of response body unlike bufio.Scanner.
+type streamResponseBodyReader struct {
+	reader *bufio.Reader
+	buf    bytes.Buffer
+}
+
+// newStreamResponseBodyReader returns an instance of streamResponseBodyReader
+// for the given Twitter stream response body.
+func newStreamResponseBodyReader(body io.Reader) *streamResponseBodyReader {
+	return &streamResponseBodyReader{reader: bufio.NewReader(body)}
+}
+
+// readNext reads Twitter stream response body and returns the next stream
+// content if exists. Returns io.EOF error if we reached the end of the stream
+// and there's no more message to read.
+func (r *streamResponseBodyReader) readNext() ([]byte, error) {
+	// Discard all the bytes from buf and continue to use the allocated memory
+	// space for reading the next message.
+	r.buf.Truncate(0)
+	for {
+		// Twitter stream messages are separated with "\r\n", and a valid
+		// message may sometimes contain '\n' in the middle.
+		// bufio.Reader.Read() can accept one byte delimiter only, so we need to
+		// first break out each line on '\n' and then check whether the line ends
+		// with "\r\n" to find message boundaries.
+		// https://dev.twitter.com/streaming/overview/processing
+		line, err := r.reader.ReadBytes('\n')
+		// Non-EOF error should be propagated to callers immediately.
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		// EOF error means that we reached the end of the stream body before finding
+		// delimiter '\n'. If "line" is empty, it means the reader didn't read any
+		// data from the stream before reaching EOF and there's nothing to append to
+		// buf.
+		if err == io.EOF && len(line) == 0 {
+			// if buf has no data, propagate io.EOF to callers and let them know that
+			// we've finished processing the stream.
+			if r.buf.Len() == 0 {
+				return nil, err
+			}
+			// Otherwise, we still have a remaining stream message to return.
+			break
+		}
+		// If the line ends with "\r\n", it's the end of one stream message data.
+		if bytes.HasSuffix(line, []byte("\r\n")) {
+			// reader.ReadBytes() returns a slice including the delimiter itself, so
+			// we need to trim '\n' as well as '\r' from the end of the slice.
+			r.buf.Write(bytes.TrimRight(line, "\r\n"))
+			break
+		}
+		// Otherwise, the line is not the end of a stream message, so we append
+		// the line to buf and continue to scan lines.
+		r.buf.Write(line)
+	}
+
+	// Get the stream message bytes from buf. Not that Bytes() won't mark the
+	// returned data as "read", and we need to explicitly call Truncate(0) to
+	// discard from buf before writing the next stream message to buf.
+	return r.buf.Bytes(), nil
 }

--- a/twitter/stream_utils_test.go
+++ b/twitter/stream_utils_test.go
@@ -1,6 +1,10 @@
 package twitter
 
 import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,4 +42,70 @@ func TestSleepOrDone_Done(t *testing.T) {
 	close(done)
 	// assert that SleepOrDone exited, closing completed
 	assertDone(t, completed, defaultTestTimeout)
+}
+
+func TestStreamResponseBodyReader(t *testing.T) {
+	cases := []struct {
+		in   []byte
+		want [][]byte
+	}{
+		{
+			in: []byte("foo\r\nbar\r\n"),
+			want: [][]byte{
+				[]byte("foo"),
+				[]byte("bar"),
+			},
+		},
+		{
+			in: []byte("foo\nbar\r\n"),
+			want: [][]byte{
+				[]byte("foo\nbar"),
+			},
+		},
+		{
+			in: []byte("foo\r\n\r\n"),
+			want: [][]byte{
+				[]byte("foo"),
+				[]byte(""),
+			},
+		},
+		{
+			in: []byte("foo\r\nbar"),
+			want: [][]byte{
+				[]byte("foo"),
+				[]byte("bar"),
+			},
+		},
+		{
+			// Message length is more than bufio.MaxScanTokenSize, which can't be
+			// parsed by bufio.Scanner with default buffer size.
+			in: []byte(strings.Repeat("X", bufio.MaxScanTokenSize+1) + "\r\n"),
+			want: [][]byte{
+				[]byte(strings.Repeat("X", bufio.MaxScanTokenSize+1)),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		body := bytes.NewReader(c.in)
+		reader := newStreamResponseBodyReader(body)
+
+		for i, want := range c.want {
+			data, err := reader.readNext()
+			if err != nil {
+				t.Errorf("reader(%q).readNext() * %d: err == %q, want nil", c.in, i, err)
+			}
+			if !bytes.Equal(data, want) {
+				t.Errorf("reader(%q).readNext() * %d: data == %q, want %q", c.in, i, data, want)
+			}
+		}
+
+		data, err := reader.readNext()
+		if err != io.EOF {
+			t.Errorf("reader(%q).readNext() * %d: err == %q, want io.EOF", c.in, len(c.want), err)
+		}
+		if len(data) != 0 {
+			t.Errorf("reader(%q).readNext() * %d: data == %q, want \"\"", c.in, len(c.want), data)
+		}
+	}
 }

--- a/twitter/stream_utils_test.go
+++ b/twitter/stream_utils_test.go
@@ -39,26 +39,3 @@ func TestSleepOrDone_Done(t *testing.T) {
 	// assert that SleepOrDone exited, closing completed
 	assertDone(t, completed, defaultTestTimeout)
 }
-
-func TestScanLines(t *testing.T) {
-	cases := []struct {
-		input   []byte
-		atEOF   bool
-		advance int
-		token   []byte
-	}{
-		{[]byte("Line 1\r\n"), false, 8, []byte("Line 1")},
-		{[]byte("Line 1\n"), false, 0, nil},
-		{[]byte("Line 1"), false, 0, nil},
-		{[]byte(""), false, 0, nil},
-		{[]byte("Line 1\r\n"), true, 8, []byte("Line 1")},
-		{[]byte("Line 1\n"), true, 7, []byte("Line 1")},
-		{[]byte("Line 1"), true, 6, []byte("Line 1")},
-		{[]byte(""), true, 0, nil},
-	}
-	for _, c := range cases {
-		advance, token, _ := scanLines(c.input, c.atEOF)
-		assert.Equal(t, c.advance, advance)
-		assert.Equal(t, c.token, token)
-	}
-}


### PR DESCRIPTION
Fixes #73 by replacing `bufio.Scanner` with `bufio.Reader` for parsing streaming data.

`bufio.Scanner` has a line length limit (65,536 bytes by default), which will cause a problem when a user has a large number of friends (say 7,000) and Twitter sends the list of all friend IDs right after establishing User Stream connection. `bufio.Reader` doesn't have the limit and the same problem won't happen.