### PR TITLE
Remove comment to avoid IDE to identify Tweet type struct as deprecated

### DIFF
--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -9,7 +9,6 @@ import (
 
 // Tweet represents a Twitter Tweet, previously called a status.
 // https://dev.twitter.com/overview/api/tweets
-// Deprecated fields: Contributors, Geo, Annotations
 type Tweet struct {
 	Coordinates          *Coordinates           `json:"coordinates"`
 	CreatedAt            string                 `json:"created_at"`


### PR DESCRIPTION
The comment on line 12 includes the word "Deprecated". This is causing some IDEs to mark the entire type struct as deprecated, causing warnings to be issued every time code using the type struct is committed.