### PR TITLE
use HTTP Form instead of URL queries for Stream Filter parameters

### DIFF
--- a/twitter/streams.go
+++ b/twitter/streams.go
@@ -50,7 +50,7 @@ type StreamFilterParams struct {
 // Filter returns messages that match one or more filter predicates.
 // https://dev.twitter.com/streaming/reference/post/statuses/filter
 func (srv *StreamService) Filter(params *StreamFilterParams) (*Stream, error) {
-	req, err := srv.public.New().Post("filter.json").QueryStruct(params).Request()
+	req, err := srv.public.New().Post("filter.json").BodyForm(params).Request()
 	if err != nil {
 		return nil, err
 	}

--- a/twitter/streams_test.go
+++ b/twitter/streams_test.go
@@ -95,7 +95,7 @@ func TestStream_Filter(t *testing.T) {
 	reqCount := 0
 	mux.HandleFunc("/1.1/statuses/filter.json", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "POST", r)
-		assertQuery(t, map[string]string{"track": "gophercon,golang"}, r)
+		assertPostForm(t, map[string]string{"track": "gophercon,golang"}, r)
 		switch reqCount {
 		case 0:
 			w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
The `POST statuses/filter` accepts both GET and POST requests.

Using URL queries to pass on the User IDs or Track queries can cause the streaming to fail silently because the URL gets too long. This Pull Requests fixes this by always using POST Forms to pass on the filtering methods. 