### PR TITLE
Support new Direct Message Events API

### DIFF
--- a/twitter/direct_messages.go
+++ b/twitter/direct_messages.go
@@ -17,7 +17,7 @@ type DirectMessageEvent struct {
 // MessageEvent is a signle direct message sent or received
 type MessageEvent struct {
 	Type      string   `json:"type"`
-	ID        int64    `json:"id"`
+	ID        int64    `json:"id,string"`
 	CreatedAt string   `json:"created_timestamp"`
 	Message   *Message `json:"message_create"`
 }

--- a/twitter/direct_messages.go
+++ b/twitter/direct_messages.go
@@ -22,7 +22,7 @@ type DirectMessageEvent struct {
 	Message   *DirectMessageEventMessage `json:"message_create"`
 }
 
-// Message contains the Sender data as well as the Message contents
+// DirectMessageEventMessage contains the Sender data as well as the Message contents
 type DirectMessageEventMessage struct {
 	SenderID int64 `json:"sender_id,string"`
 	Target   struct {
@@ -31,7 +31,7 @@ type DirectMessageEventMessage struct {
 	Data *DirectMessageEventMessageData `json:"message_data"`
 }
 
-// MessageData contains the raw text of the message sent or received
+// DirectMessageEventMessageData contains the raw text of the message sent or received
 type DirectMessageEventMessageData struct {
 	Text     string    `json:"text"`
 	Entities *Entities `json:"entitites"`

--- a/twitter/direct_messages.go
+++ b/twitter/direct_messages.go
@@ -7,6 +7,45 @@ import (
 	"github.com/dghubble/sling"
 )
 
+// DirectMessageEvent is a list direct message event
+type DirectMessageEvent struct {
+	NextCursor string         `json:"next_cursor"`
+	Events     []MessageEvent `json:"events"`
+	Apps       string         `json:"apps"`
+}
+
+// MessageEvent is a signle direct message sent or received
+type MessageEvent struct {
+	Type      string   `json:"type"`
+	ID        int64    `json:"id"`
+	CreatedAt string   `json:"created_timestamp"`
+	Message   *Message `json:"message_create"`
+}
+
+// Message contains the Sender data as well as the Message contents
+type Message struct {
+	SenderID string       `json:"sender_id"`
+	Target   *Target      `json:"target"`
+	Data     *MessageData `json:"message_data"`
+}
+
+// Target recipient information
+type Target struct {
+	RecipientID string `json:"recipient_id"`
+}
+
+// MessageData contains the raw text of the message sent or received
+type MessageData struct {
+	Text     string    `json:"text"`
+	Entities *Entities `json:"entitites"`
+}
+
+// DirectMessageEventsGetParams are the parameters for DirectMessageEvents.Get
+type DirectMessageEventsGetParams struct {
+	NextCursor string `url:"cursor,omitempty"`
+	Count      int    `url:"count,omitempty"`
+}
+
 // DirectMessage is a direct message to a single recipient.
 type DirectMessage struct {
 	CreatedAt           string    `json:"created_at"`
@@ -75,6 +114,16 @@ func (s *DirectMessageService) Get(params *DirectMessageGetParams) ([]DirectMess
 	apiError := new(APIError)
 	resp, err := s.baseSling.New().Get("direct_messages.json").QueryStruct(params).Receive(dms, apiError)
 	return *dms, resp, relevantError(err, *apiError)
+}
+
+// GetEvents returns recent Direct Message Events received or sent by the authenticated user.
+// Requires a user auth context with DM scope.
+// https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events
+func (s *DirectMessageService) GetEvents(params *DirectMessageEventsGetParams) (DirectMessageEvent, *http.Response, error) {
+	event := new(DirectMessageEvent)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("events/list.json").QueryStruct(params).Receive(event, apiError)
+	return *event, resp, relevantError(err, *apiError)
 }
 
 // DirectMessageSentParams are the parameters for DirectMessageService.Sent


### PR DESCRIPTION
The existing API's for Direct Messages is being shut down on Aug 16st, 2018: https://twitter.com/TwitterDev/status/996783000741384192

This pull request is based on @listonb work in
https://github.com/dghubble/go-twitter/pull/87

No tests have been written for this single, new API call. However, before I spend anymore time on this I would like to see this discussed/approved/merged so I can continue to use the this great library.