### PR TITLE
Add attachment field to DirectMessageEvent message data

### DIFF
--- a/twitter/direct_messages.go
+++ b/twitter/direct_messages.go
@@ -30,8 +30,12 @@ type DirectMessageEventMessage struct {
 		RecipientID string `json:"recipient_id"`
 	} `json:"target"`
 	Data struct {
-		Text     string    `json:"text"`
-		Entities *Entities `json:"entitites"`
+		Text       string    `json:"text"`
+		Entities   *Entities `json:"entitites"`
+		Attachment struct {
+			Type  string      `json:"type"`
+			Media MediaEntity `json:"media"`
+		} `json:"attachment"`
 	} `json:"message_data"`
 }
 


### PR DESCRIPTION
The `attachement` media entity struct was left out of the schema for the new Direct Messages API.