### PR TITLE
Adds basic account account activities API and DM improvements

### DIFF
--- a/twitter/account_activities.go
+++ b/twitter/account_activities.go
@@ -1,0 +1,47 @@
+package twitter
+
+import (
+	"github.com/dghubble/sling"
+	"net/http"
+)
+
+// AccountActivityService provides methods for accessing Twitter's account
+// activities endpoints
+type AccountActivityService struct {
+	sling *sling.Sling
+}
+
+// AccountActivityRegisterWebhookParams are the parameters used for registering
+// a webhook on the account activities API.
+type AccountActivityRegisterWebhookParams struct {
+	EnvName string
+	URL     string `url:"url"`
+}
+
+// AccountActivityWebhook contains information about a webhook created on the account activity
+// API
+type AccountActivityWebhook struct {
+	ID        string `json:"id"`
+	URL       string `json:"url"`
+	Valid     bool   `json:"valid"`
+	CreatedAt string `json:"created_at"`
+}
+
+func newAccountActivityService(sling *sling.Sling) *AccountActivityService {
+	return &AccountActivityService{
+		sling: sling.Path("account_activity/"),
+	}
+}
+
+// RegisterWebhook registers a given URL as a webhook for the account
+// activities API
+func (s *AccountActivityService) RegisterWebhook(params *AccountActivityRegisterWebhookParams) (*AccountActivityWebhook, *http.Response, error) {
+	if params == nil {
+		params = &AccountActivityRegisterWebhookParams{}
+	}
+	apiError := new(APIError)
+	webhook := new(AccountActivityWebhook)
+	resp, err := s.sling.New().Post("all/"+params.EnvName+"/webhooks.json").BodyForm(params).Receive(webhook, apiError)
+
+	return webhook, resp, relevantError(err, *apiError)
+}

--- a/twitter/account_activities.go
+++ b/twitter/account_activities.go
@@ -18,6 +18,12 @@ type AccountActivityRegisterWebhookParams struct {
 	URL     string `url:"url"`
 }
 
+// CreateSubscriptionParams are the parameters used for subscribing to events
+// for a given user
+type AccountActivityCreateSubscriptionParams struct {
+	EnvName string
+}
+
 // AccountActivityWebhook contains information about a webhook created on the account activity
 // API
 type AccountActivityWebhook struct {
@@ -44,4 +50,16 @@ func (s *AccountActivityService) RegisterWebhook(params *AccountActivityRegister
 	resp, err := s.sling.New().Post("all/"+params.EnvName+"/webhooks.json").BodyForm(params).Receive(webhook, apiError)
 
 	return webhook, resp, relevantError(err, *apiError)
+}
+
+// CreateSubscription subscribes the application's webhooks to all of the
+// authenticated user's events
+func (s *AccountActivityService) CreateSubscription(params *AccountActivityCreateSubscriptionParams) (*http.Response, error) {
+	if params == nil {
+		params = &AccountActivityCreateSubscriptionParams{}
+	}
+	apiError := new(APIError)
+	resp, err := s.sling.New().Post("all/"+params.EnvName+"/subscriptions.json").BodyForm(params).Receive(nil, apiError)
+
+	return resp, relevantError(err, *apiError)
 }

--- a/twitter/direct_messages.go
+++ b/twitter/direct_messages.go
@@ -9,9 +9,17 @@ import (
 
 // DirectMessageEvents lists Direct Message events.
 type DirectMessageEvents struct {
-	Apps       string               `json:"apps"`
-	Events     []DirectMessageEvent `json:"events"`
-	NextCursor string               `json:"next_cursor"`
+	Apps       map[string]ApplicationInfo `json:"apps"`
+	Events     []DirectMessageEvent       `json:"events"`
+	NextCursor string                     `json:"next_cursor"`
+}
+
+// ApplicationInfo contains information about applications associated with an
+// account (this field is returned when listing direct message events).
+type ApplicationInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
 }
 
 // DirectMessageEvent is a single Direct Message sent or received.

--- a/twitter/twitter.go
+++ b/twitter/twitter.go
@@ -12,37 +12,39 @@ const twitterAPI = "https://api.twitter.com/1.1/"
 type Client struct {
 	sling *sling.Sling
 	// Twitter API Services
-	Accounts       *AccountService
-	DirectMessages *DirectMessageService
-	Favorites      *FavoriteService
-	Followers      *FollowerService
-	Friends        *FriendService
-	Friendships    *FriendshipService
-	Search         *SearchService
-	Statuses       *StatusService
-	Streams        *StreamService
-	Timelines      *TimelineService
-	Trends         *TrendsService
-	Users          *UserService
+	Accounts        *AccountService
+	AccountActivity *AccountActivityService
+	DirectMessages  *DirectMessageService
+	Favorites       *FavoriteService
+	Followers       *FollowerService
+	Friends         *FriendService
+	Friendships     *FriendshipService
+	Search          *SearchService
+	Statuses        *StatusService
+	Streams         *StreamService
+	Timelines       *TimelineService
+	Trends          *TrendsService
+	Users           *UserService
 }
 
 // NewClient returns a new Client.
 func NewClient(httpClient *http.Client) *Client {
 	base := sling.New().Client(httpClient).Base(twitterAPI)
 	return &Client{
-		sling:          base,
-		Accounts:       newAccountService(base.New()),
-		DirectMessages: newDirectMessageService(base.New()),
-		Favorites:      newFavoriteService(base.New()),
-		Followers:      newFollowerService(base.New()),
-		Friends:        newFriendService(base.New()),
-		Friendships:    newFriendshipService(base.New()),
-		Search:         newSearchService(base.New()),
-		Statuses:       newStatusService(base.New()),
-		Streams:        newStreamService(httpClient, base.New()),
-		Timelines:      newTimelineService(base.New()),
-		Trends:         newTrendsService(base.New()),
-		Users:          newUserService(base.New()),
+		sling:           base,
+		AccountActivity: newAccountActivityService(base.New()),
+		Accounts:        newAccountService(base.New()),
+		DirectMessages:  newDirectMessageService(base.New()),
+		Favorites:       newFavoriteService(base.New()),
+		Followers:       newFollowerService(base.New()),
+		Friends:         newFriendService(base.New()),
+		Friendships:     newFriendshipService(base.New()),
+		Search:          newSearchService(base.New()),
+		Statuses:        newStatusService(base.New()),
+		Streams:         newStreamService(httpClient, base.New()),
+		Timelines:       newTimelineService(base.New()),
+		Trends:          newTrendsService(base.New()),
+		Users:           newUserService(base.New()),
 	}
 }
 


### PR DESCRIPTION
I've ended up needing these endpoints for another project I'm working on. The account activities API isn't complete, but it's a starting point with the basics that people can use/base further work on.