### PR TITLE
Add DirectMessageEvents API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ go-twitter is a Go client library for the [Twitter API](https://dev.twitter.com/
 
 * Twitter REST API:
     * Accounts
-    * Direct Messages
+    * DirectMessageEvents
     * Favorites
     * Friends
     * Friendships

--- a/examples/direct_messages.go
+++ b/examples/direct_messages.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/coreos/pkg/flagutil"
+	"github.com/dghubble/go-twitter/twitter"
+	"github.com/dghubble/oauth1"
+)
+
+func main() {
+	flags := flag.NewFlagSet("user-auth", flag.ExitOnError)
+	consumerKey := flags.String("consumer-key", "", "Twitter Consumer Key")
+	consumerSecret := flags.String("consumer-secret", "", "Twitter Consumer Secret")
+	accessToken := flags.String("access-token", "", "Twitter Access Token")
+	accessSecret := flags.String("access-secret", "", "Twitter Access Secret")
+	flags.Parse(os.Args[1:])
+	flagutil.SetFlagsFromEnv(flags, "TWITTER")
+
+	if *consumerKey == "" || *consumerSecret == "" || *accessToken == "" || *accessSecret == "" {
+		log.Fatal("Consumer key/secret and Access token/secret required")
+	}
+
+	config := oauth1.NewConfig(*consumerKey, *consumerSecret)
+	token := oauth1.NewToken(*accessToken, *accessSecret)
+	// OAuth1 http.Client will automatically authorize Requests
+	httpClient := config.Client(oauth1.NoContext, token)
+
+	// Twitter client
+	client := twitter.NewClient(httpClient)
+
+	// List most recent 10 Direct Messages
+	messages, _, err := client.DirectMessages.EventsList(
+		&twitter.DirectMessageEventsListParams{Count: 10},
+	)
+	fmt.Println("User's DIRECT MESSAGES:")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, event := range messages.Events {
+		fmt.Printf("%+v\n", event)
+		fmt.Printf("  %+v\n", event.Message)
+		fmt.Printf("  %+v\n", event.Message.Data)
+	}
+
+	// Show Direct Message event
+	event, _, err := client.DirectMessages.EventsShow("1066903366071017476", nil)
+	fmt.Printf("DM Events Show:\n%+v, %v\n", event.Message.Data, err)
+
+	// Create Direct Message event
+	/*
+		event, _, err = client.DirectMessages.EventsNew(&twitter.DirectMessageEventsNewParams{
+			Event: &twitter.DirectMessageEvent{
+				Type: "message_create",
+				Message: &twitter.DirectMessageEventMessage{
+					Target: &twitter.DirectMessageTarget{
+						RecipientID: "2856535627",
+					},
+					Data: &twitter.DirectMessageData{
+						Text: "testing",
+					},
+				},
+			},
+		})
+		fmt.Printf("DM Event New:\n%+v, %v\n", event, err)
+	*/
+
+	// Destroy Direct Message event
+	//_, err = client.DirectMessages.EventsDestroy("1066904217049133060")
+	//fmt.Printf("DM Events Delete:\n err: %v\n", err)
+}

--- a/examples/user-auth.go
+++ b/examples/user-auth.go
@@ -67,14 +67,4 @@ func main() {
 	// Update (POST!) Tweet (uncomment to run)
 	// tweet, _, _ := client.Statuses.Update("just setting up my twttr", nil)
 	// fmt.Printf("Posted Tweet\n%v\n", tweet)
-
-	// List most recent 3 Direct Messages
-	messages, _, _ := client.DirectMessages.EventsList(
-		&twitter.DirectMessageEventsListParams{Count: 3},
-	)
-	fmt.Println("User's DIRECT MESSAGES:")
-	for _, event := range messages.Events {
-		fmt.Printf("%+v\n", event)
-		fmt.Printf("%+v\n", event.Message)
-	}
 }

--- a/twitter/direct_messages_test.go
+++ b/twitter/direct_messages_test.go
@@ -9,6 +9,47 @@ import (
 )
 
 var (
+	testDMEvent = DirectMessageEvent{
+		CreatedAt: "1542410751275",
+		ID:        "1063573894173323269",
+		Type:      "message_create",
+		Message: &DirectMessageEventMessage{
+			SenderID: "623265148",
+			Target: &DirectMessageTarget{
+				RecipientID: "3694959333",
+			},
+			Data: &DirectMessageData{
+				Text: "example",
+			},
+		},
+	}
+	testDMEventID   = "1063573894173323269"
+	testDMEventJSON = `
+{
+	"type": "message_create",
+	"id": "1063573894173323269",
+	"created_timestamp": "1542410751275",
+	"message_create": {
+		"target": {
+			"recipient_id": "3694959333"
+		},
+		"sender_id": "623265148",
+		"message_data": {
+			"text": "example",
+			"entities": {
+				"hashtags": [],
+				"symbols": [],
+				"user_mentions": [],
+				"urls": []
+			}
+		}
+  }
+}`
+	testDMEventShowJSON     = `{"event": ` + testDMEventJSON + `}`
+	testDMEventListJSON     = `{"events": [` + testDMEventJSON + `], "next_cursor": "AB345dkfC"}`
+	testDMEventNewInputJSON = `{"event":{"type":"message_create","message_create":{"target":{"recipient_id":"3694959333"},"message_data":{"text":"example"}}}}
+`
+	// DEPRECATED
 	testDM = DirectMessage{
 		ID:        240136858829479936,
 		Recipient: &User{ScreenName: "theSeanCook"},
@@ -18,6 +59,119 @@ var (
 	testDMIDStr = "240136858829479936"
 	testDMJSON  = `{"id": 240136858829479936,"recipient": {"screen_name": "theSeanCook"},"sender": {"screen_name": "s0c1alm3dia"},"text": "hello world"}`
 )
+
+func TestDirectMessageService_EventsNew(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/events/new.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertPostJSON(t, testDMEventNewInputJSON, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, testDMEventShowJSON)
+	})
+
+	client := NewClient(httpClient)
+	event, _, err := client.DirectMessages.EventsNew(&DirectMessageEventsNewParams{
+		Event: &DirectMessageEvent{
+			Type: "message_create",
+			Message: &DirectMessageEventMessage{
+				Target: &DirectMessageTarget{
+					RecipientID: "3694959333",
+				},
+				Data: &DirectMessageData{
+					Text: "example",
+				},
+			},
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, &testDMEvent, event)
+}
+
+func TestDirectMessageService_EventsShow(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/events/show.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"id": testDMEventID}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, testDMEventShowJSON)
+	})
+
+	client := NewClient(httpClient)
+	event, _, err := client.DirectMessages.EventsShow(testDMEventID, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, &testDMEvent, event)
+}
+
+func TestDirectMessageService_EventsList(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/events/list.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"count": "10"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, testDMEventListJSON)
+	})
+	expected := &DirectMessageEvents{
+		Events:     []DirectMessageEvent{testDMEvent},
+		NextCursor: "AB345dkfC",
+	}
+
+	client := NewClient(httpClient)
+	events, _, err := client.DirectMessages.EventsList(&DirectMessageEventsListParams{Count: 10})
+	assert.Equal(t, expected, events)
+	assert.Nil(t, err)
+}
+
+func TestDirectMessageService_EventsDestroy(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/events/destroy.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "DELETE", r)
+		assertQuery(t, map[string]string{"id": testDMEventID}, r)
+		w.Header().Set("Content-Type", "application/json")
+		// successful delete returns 204 No Content
+		w.WriteHeader(204)
+	})
+
+	client := NewClient(httpClient)
+	resp, err := client.DirectMessages.EventsDestroy(testDMEventID)
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestDirectMessageService_EventsDestroyError(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/direct_messages/events/destroy.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "DELETE", r)
+		assertQuery(t, map[string]string{"id": testDMEventID}, r)
+		w.Header().Set("Content-Type", "application/json")
+		// failure to delete event that doesn't exist
+		w.WriteHeader(404)
+		fmt.Fprintf(w, `{"errors":[{"code": 34, "message": "Sorry, that page does not exist"}]}`)
+	})
+	expected := APIError{
+		Errors: []ErrorDetail{
+			ErrorDetail{Code: 34, Message: "Sorry, that page does not exist"},
+		},
+	}
+
+	client := NewClient(httpClient)
+	resp, err := client.DirectMessages.EventsDestroy(testDMEventID)
+	assert.NotNil(t, resp)
+	if assert.Error(t, err) {
+		assert.Equal(t, expected, err)
+	}
+}
+
+// DEPRECATED
 
 func TestDirectMessageService_Show(t *testing.T) {
 	httpClient, mux, server := testServer()

--- a/twitter/twitter_test.go
+++ b/twitter/twitter_test.go
@@ -1,6 +1,7 @@
 package twitter
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -66,6 +67,13 @@ func assertPostForm(t *testing.T, expected map[string]string, req *http.Request)
 		expectedValues.Add(key, value)
 	}
 	assert.Equal(t, expectedValues, req.Form)
+}
+
+// assertPostJSON tests that the Request has the expected JSON body.
+func assertPostJSON(t *testing.T, expected string, req *http.Request) {
+	data, err := ioutil.ReadAll(req.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(data))
 }
 
 // assertDone asserts that the empty struct channel is closed before the given


### PR DESCRIPTION
Add `DirectMessageService` support for the new Twitter Direct Message Events [API](https://developer.twitter.com/en/docs/direct-messages/api-features).

* Add `EventsNew` method for sending a Direct Message event
* Add `EventsShow` method for getting a single Direct Message event
* Add missing test coverage for `EventsList` method
* Add`EventsDestroy` method for destroying a Direct Message event
* Move DirectMessageEvents example to its own `go run`-able file

New and Show return a `*DirectMessageEvent` directly, keeping wrapper objects out of user code where possible. New accepts a param type containing a `*DirectMessageEvent` so messages can be constructed and consumed in similar ways. Unlike prior Twitter endpoints `EventsDestroy` doesn't provide the destroyed object, only an error for checking success.

The previous Direct Message API endpoints have been shutdown (e.g. `direct_messages`, `direct_messages/sent`, `direct_messages/show`, `direct_messages/new`, `direct_messages/destroy`) per [a post](https://twittercommunity.com/t/building-on-site-streams-user-streams-or-direct-messages-action-required-to-preserve-and-prevent-disruption-to-your-twitter-integration/105736) on Twitter's forum.

Closes: #122 #117 #118 #123