### PR TITLE
Support Premium Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ go-twitter is a Go client library for the [Twitter API](https://dev.twitter.com/
     * Friendships
     * Followers
     * Lists
+    * PremiumSearch
     * RateLimits
     * Search
     * Statuses

--- a/twitter/premium_search.go
+++ b/twitter/premium_search.go
@@ -1,0 +1,116 @@
+package twitter
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// PremiumSearch represents the result of a Tweet search.
+// https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search
+type PremiumSearch struct {
+	Results           []Tweet            `json:"results"`
+	Next              string             `json:"next"`
+	RequestParameters *RequestParameters `json:"requestParameters"`
+}
+
+// RequestParameters describes a request parameter that was passed to a Premium search API.
+type RequestParameters struct {
+	MaxResults int    `json:"maxResults"`
+	FromDate   string `json:"fromDate"`
+	ToDate     string `json:"toDate"`
+}
+
+// PremiumSearchCount describes a response of Premium search API's count endpoint.
+// https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search#CountsEndpoint
+type PremiumSearchCount struct {
+	Results           []TweetCount            `json:"results"`
+	TotalCount        int64                   `json:"totalCount"`
+	RequestParameters *RequestCountParameters `json:"requestParameters"`
+}
+
+// RequestCountParameters describes a request parameter that was passed to a Premium search API.
+type RequestCountParameters struct {
+	Bucket   string `json:"bucket"`
+	FromDate string `json:"fromDate"`
+	ToDate   string `json:"toDate"`
+}
+
+// TweetCount represents a count of Tweets in the TimePeriod matching a search query.
+type TweetCount struct {
+	TimePeriod string `json:"timePeriod"`
+	Count      int64  `json:"count"`
+}
+
+// PremiumSearchService provides methods for accessing Twitter premium search API endpoints.
+type PremiumSearchService struct {
+	sling *sling.Sling
+}
+
+// newSearchService returns a new SearchService.
+func newPremiumSearchService(sling *sling.Sling) *PremiumSearchService {
+	return &PremiumSearchService{
+		sling: sling.Path("tweets/search/"),
+	}
+}
+
+// PremiumSearchTweetParams are the parameters for PremiumSearchService.SearchFullArchive and Search30Days
+type PremiumSearchTweetParams struct {
+	Query      string `url:"query,omitempty"`
+	Tag        string `url:"tag,omitempty"`
+	FromDate   string `url:"fromDate,omitempty"`
+	ToDate     string `url:"toDate,omitempty"`
+	MaxResults int    `url:"maxResults,omitempty"`
+	Next       string `url:"next,omitempty"`
+}
+
+// PremiumSearchCountTweetParams are the parameters for PremiumSearchService.CountFullArchive and Count30Days
+type PremiumSearchCountTweetParams struct {
+	Query    string `url:"query,omitempty"`
+	Tag      string `url:"tag,omitempty"`
+	FromDate string `url:"fromDate,omitempty"`
+	ToDate   string `url:"toDate,omitempty"`
+	Bucket   string `url:"bucket,omitempty"`
+	Next     string `url:"next,omitempty"`
+}
+
+// SearchFullArchive returns a collection of Tweets matching a search query from tweets back to the very first tweet.
+// https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search
+func (s *PremiumSearchService) SearchFullArchive(params *PremiumSearchTweetParams, label string) (*PremiumSearch, *http.Response, error) {
+	search := new(PremiumSearch)
+	apiError := new(APIError)
+	path := fmt.Sprintf("fullarchive/%s.json", label)
+	resp, err := s.sling.New().Get(path).QueryStruct(params).Receive(search, apiError)
+	return search, resp, relevantError(err, *apiError)
+}
+
+// Search30Days returns a collection of Tweets matching a search query from Tweets posted within the last 30 days.
+// https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search
+func (s *PremiumSearchService) Search30Days(params *PremiumSearchTweetParams, label string) (*PremiumSearch, *http.Response, error) {
+	search := new(PremiumSearch)
+	apiError := new(APIError)
+	path := fmt.Sprintf("30day/%s.json", label)
+	resp, err := s.sling.New().Get(path).QueryStruct(params).Receive(search, apiError)
+	return search, resp, relevantError(err, *apiError)
+}
+
+// CountFullArchive returns a counts of Tweets matching a search query from tweets back to the very first tweet.
+// https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search#CountsEndpoint
+func (s *PremiumSearchService) CountFullArchive(params *PremiumSearchCountTweetParams, label string) (*PremiumSearchCount, *http.Response, error) {
+	counts := new(PremiumSearchCount)
+	apiError := new(APIError)
+	path := fmt.Sprintf("fullarchive/%s/counts.json", label)
+	resp, err := s.sling.New().Get(path).QueryStruct(params).Receive(counts, apiError)
+	return counts, resp, relevantError(err, *apiError)
+}
+
+// Count30Days returns a counts of Tweets matching a search query from Tweets posted within the last 30 days.
+// https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search#CountsEndpoint
+func (s *PremiumSearchService) Count30Days(params *PremiumSearchCountTweetParams, label string) (*PremiumSearchCount, *http.Response, error) {
+	counts := new(PremiumSearchCount)
+	apiError := new(APIError)
+	path := fmt.Sprintf("30day/%s/counts.json", label)
+	resp, err := s.sling.New().Get(path).QueryStruct(params).Receive(counts, apiError)
+	return counts, resp, relevantError(err, *apiError)
+}

--- a/twitter/premium_search_test.go
+++ b/twitter/premium_search_test.go
@@ -1,0 +1,140 @@
+package twitter
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPremiumSearchService_Tweets(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	assertSearchBody := func(t *testing.T, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"query": "url:\"http://example.com\"", "tag": "8HYG54ZGTU", "fromDate": "201512220000", "toDate": "201712220000", "maxResults": "500", "next": "NTcxODIyMDMyODMwMjU1MTA0"}, r)
+	}
+	setResponse := func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"results":[{"id":781760642139250689}],"next":"NTcxODIyMDMyODMwMjU1MTA0","requestParameters":{"maxResults":500,"fromDate":"201512200000","toDate":"201712200000"}}`)
+	}
+
+	mux.HandleFunc("/1.1/tweets/search/fullarchive/test.json", func(w http.ResponseWriter, r *http.Request) {
+		assertSearchBody(t, r)
+		setResponse(w)
+	})
+	mux.HandleFunc("/1.1/tweets/search/30day/test.json", func(w http.ResponseWriter, r *http.Request) {
+		assertSearchBody(t, r)
+		setResponse(w)
+	})
+
+	params := &PremiumSearchTweetParams{
+		Query:      "url:\"http://example.com\"",
+		Tag:        "8HYG54ZGTU",
+		FromDate:   "201512220000",
+		ToDate:     "201712220000",
+		MaxResults: 500,
+		Next:       "NTcxODIyMDMyODMwMjU1MTA0",
+	}
+	expected := &PremiumSearch{
+		Results: []Tweet{
+			Tweet{ID: 781760642139250689},
+		},
+		Next: "NTcxODIyMDMyODMwMjU1MTA0",
+		RequestParameters: &RequestParameters{
+			MaxResults: 500,
+			FromDate:   "201512200000",
+			ToDate:     "201712200000",
+		},
+	}
+
+	{
+		client := NewClient(httpClient)
+		search, _, err := client.PremiumSearch.SearchFullArchive(
+			params,
+			"test",
+		)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, search)
+	}
+	{
+		client := NewClient(httpClient)
+		search, _, err := client.PremiumSearch.Search30Days(
+			params,
+			"test",
+		)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, search)
+	}
+}
+
+func TestPremiumSearchService_Counts(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	assertCountBody := func(t *testing.T, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"query": "url:\"http://example.com\"", "tag": "8HYG54ZGTU", "fromDate": "201512220000", "toDate": "201712220000", "bucket": "day", "next": "NTcxODIyMDMyODMwMjU1MTA0"}, r)
+	}
+	setResponse := func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"results":[{"timePeriod":"201701010000","count":32},{"timePeriod":"201701020000","count":45}],"totalCount":2027,"requestParameters":{"bucket":"day","fromDate":"201512200000","toDate":"201712200000"}}`)
+	}
+
+	mux.HandleFunc("/1.1/tweets/search/fullarchive/test/counts.json", func(w http.ResponseWriter, r *http.Request) {
+		assertCountBody(t, r)
+		setResponse(w)
+	})
+	mux.HandleFunc("/1.1/tweets/search/30day/test/counts.json", func(w http.ResponseWriter, r *http.Request) {
+		assertCountBody(t, r)
+		setResponse(w)
+	})
+
+	params := &PremiumSearchCountTweetParams{
+		Query:    "url:\"http://example.com\"",
+		Tag:      "8HYG54ZGTU",
+		FromDate: "201512220000",
+		ToDate:   "201712220000",
+		Bucket:   "day",
+		Next:     "NTcxODIyMDMyODMwMjU1MTA0",
+	}
+	expected := &PremiumSearchCount{
+		Results: []TweetCount{
+			TweetCount{
+				TimePeriod: "201701010000",
+				Count:      32,
+			},
+			TweetCount{
+				TimePeriod: "201701020000",
+				Count:      45,
+			},
+		},
+		TotalCount: 2027,
+		RequestParameters: &RequestCountParameters{
+			Bucket:   "day",
+			FromDate: "201512200000",
+			ToDate:   "201712200000",
+		},
+	}
+
+	{
+		client := NewClient(httpClient)
+		search, _, err := client.PremiumSearch.CountFullArchive(
+			params,
+			"test",
+		)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, search)
+	}
+	{
+		client := NewClient(httpClient)
+		search, _, err := client.PremiumSearch.Count30Days(
+			params,
+			"test",
+		)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, search)
+	}
+}

--- a/twitter/twitter.go
+++ b/twitter/twitter.go
@@ -21,6 +21,7 @@ type Client struct {
 	Lists          *ListsService
 	RateLimits     *RateLimitService
 	Search         *SearchService
+	PremiumSearch  *PremiumSearchService
 	Statuses       *StatusService
 	Streams        *StreamService
 	Timelines      *TimelineService
@@ -42,6 +43,7 @@ func NewClient(httpClient *http.Client) *Client {
 		Lists:          newListService(base.New()),
 		RateLimits:     newRateLimitService(base.New()),
 		Search:         newSearchService(base.New()),
+		PremiumSearch:  newPremiumSearchService(base.New()),
 		Statuses:       newStatusService(base.New()),
 		Streams:        newStreamService(httpClient, base.New()),
 		Timelines:      newTimelineService(base.New()),


### PR DESCRIPTION
This PR adds supports for Twitter Premium Search API's both [Data endpoint](https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search#DataEndpoint) and [Count endpoint](https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search#CountsEndpoint).

ref: https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search
