### PR TITLE
Added Since and Filter to SearchTweetParams

### DIFF
--- a/twitter/search.go
+++ b/twitter/search.go
@@ -48,6 +48,8 @@ type SearchTweetParams struct {
 	SinceID         int64  `url:"since_id,omitempty"`
 	MaxID           int64  `url:"max_id,omitempty"`
 	Until           string `url:"until,omitempty"`
+	Since           string `url:"since,omitempty"`
+	Filter          string `url:"filter,omitempty"`
 	IncludeEntities *bool  `url:"include_entities,omitempty"`
 	TweetMode       string `url:"tweet_mode,omitempty"`
 }

--- a/twitter/search_test.go
+++ b/twitter/search_test.go
@@ -14,9 +14,9 @@ func TestSearchService_Tweets(t *testing.T) {
 
 	mux.HandleFunc("/1.1/search/tweets.json", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
-		assertQuery(t, map[string]string{"q": "happy birthday", "result_type": "popular", "count": "1"}, r)
+		assertQuery(t, map[string]string{"q": "happy birthday", "result_type": "popular", "count": "1", "since": "2012-01-01", "filter": "safe"}, r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"statuses":[{"id":781760642139250689}],"search_metadata":{"completed_in":0.043,"max_id":781760642139250689,"max_id_str":"781760642139250689","next_results":"?max_id=781760640104828927&q=happy+birthday&count=1&include_entities=1","query":"happy birthday","refresh_url":"?since_id=781760642139250689&q=happy+birthday&include_entities=1","count":1,"since_id":0,"since_id_str":"0"}}`)
+		fmt.Fprintf(w, `{"statuses":[{"id":781760642139250689}],"search_metadata":{"completed_in":0.043,"max_id":781760642139250689,"max_id_str":"781760642139250689","next_results":"?max_id=781760640104828927&q=happy+birthday&count=1&include_entities=1","query":"happy birthday","refresh_url":"?since_id=781760642139250689&q=happy+birthday&include_entities=1","count":1,"since_id":0,"since_id_str":"0", "since":"2012-01-01", "filter":"safe"}}`)
 	})
 
 	client := NewClient(httpClient)
@@ -24,7 +24,8 @@ func TestSearchService_Tweets(t *testing.T) {
 		Query:      "happy birthday",
 		Count:      1,
 		ResultType: "popular",
-	})
+		Since:      "2012-01-01",
+		Filter:     "safe"})
 	expected := &Search{
 		Statuses: []Tweet{
 			Tweet{ID: 781760642139250689},


### PR DESCRIPTION
I added two new parameters Since and Filter to SearchTweetParams

these parameters can be found here in the twitter api docu:
https://developer.twitter.com/en/docs/tweets/rules-and-filtering/overview/standard-operators.html

This closes issue #140 