### PR TITLE
Add in functionality to upload media to twitter

### DIFF
--- a/twitter/config.go
+++ b/twitter/config.go
@@ -1,0 +1,53 @@
+package twitter
+
+import (
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// Config represents the current configuration used by Twitter
+// https://developer.twitter.com/en/docs/developer-utilities/configuration
+type Config struct {
+	CharactersReservedPerMedia int         `json:"characters_reserved_per_media"`
+	DMTextCharacterLimit       int         `json:"dm_text_character_limit"`
+	MaxMediaPerUpload          int         `json:"max_media_per_upload"`
+	PhotoSizeLimit             int         `json:"photo_size_limit"`
+	PhotoSizes                 *PhotoSizes `json:"photo_sizes"`
+	ShortURLLength             int         `json:"short_url_length"`
+	ShortURLLengthHttps        int         `json:"short_url_length_https"`
+	NonUsernamePaths           []string    `json:"non_username_paths"`
+}
+
+type PhotoSizes struct {
+	Large  *SinglePhotoSize `json:"large"`
+	Medium *SinglePhotoSize `json:"medium"`
+	Small  *SinglePhotoSize `json:"small"`
+	Thumb  *SinglePhotoSize `json:"thumb"`
+}
+
+type SinglePhotoSize struct {
+	Height int    `json:"h"`
+	Width  int    `json:"w"`
+	Resize string `json:"resize"`
+}
+
+// ConfigService provides methods for accessing Twitter's config API endpoint.
+type ConfigService struct {
+	sling *sling.Sling
+}
+
+// newConfigService returns a new ConfigService.
+func newConfigService(sling *sling.Sling) *ConfigService {
+	return &ConfigService{
+		sling: sling.Path("help/"),
+	}
+}
+
+// Get fetches the current configuration.
+func (c *ConfigService) Get() (*Config, *http.Response, error) {
+	config := new(Config)
+	apiError := new(APIError)
+	resp, err := c.sling.New().Get("configuration.json").Receive(config, apiError)
+	return config, resp, relevantError(err, *apiError)
+}

--- a/twitter/config.go
+++ b/twitter/config.go
@@ -15,10 +15,11 @@ type Config struct {
 	PhotoSizeLimit             int         `json:"photo_size_limit"`
 	PhotoSizes                 *PhotoSizes `json:"photo_sizes"`
 	ShortURLLength             int         `json:"short_url_length"`
-	ShortURLLengthHttps        int         `json:"short_url_length_https"`
+	ShortURLLengthHTTPS        int         `json:"short_url_length_https"`
 	NonUsernamePaths           []string    `json:"non_username_paths"`
 }
 
+// PhotoSizes holds data for the four sizes of images that twitter supports.
 type PhotoSizes struct {
 	Large  *SinglePhotoSize `json:"large"`
 	Medium *SinglePhotoSize `json:"medium"`
@@ -26,6 +27,7 @@ type PhotoSizes struct {
 	Thumb  *SinglePhotoSize `json:"thumb"`
 }
 
+// SinglePhotoSize holds the information for a single photo size.
 type SinglePhotoSize struct {
 	Height int    `json:"h"`
 	Width  int    `json:"w"`

--- a/twitter/config_test.go
+++ b/twitter/config_test.go
@@ -20,7 +20,7 @@ func TestConfigService_Get(t *testing.T) {
 
 	client := NewClient(httpClient)
 	status, _, err := client.Config.Get()
-	expected := &Config{CharactersReservedPerMedia: 24, DMTextCharacterLimit: 10000, MaxMediaPerUpload: 1, PhotoSizeLimit: 3145728, PhotoSizes: &PhotoSizes{Large: &SinglePhotoSize{Height: 2048, Width: 1024, Resize: "fit"}, Medium: &SinglePhotoSize{Height: 1200, Width: 600, Resize: "fit"}, Small: &SinglePhotoSize{Height: 480, Width: 340, Resize: "fit"}, Thumb: &SinglePhotoSize{Height: 150, Width: 150, Resize: "crop"}}, ShortURLLength: 23, ShortURLLengthHttps: 23, NonUsernamePaths: []string{"about"}}
+	expected := &Config{CharactersReservedPerMedia: 24, DMTextCharacterLimit: 10000, MaxMediaPerUpload: 1, PhotoSizeLimit: 3145728, PhotoSizes: &PhotoSizes{Large: &SinglePhotoSize{Height: 2048, Width: 1024, Resize: "fit"}, Medium: &SinglePhotoSize{Height: 1200, Width: 600, Resize: "fit"}, Small: &SinglePhotoSize{Height: 480, Width: 340, Resize: "fit"}, Thumb: &SinglePhotoSize{Height: 150, Width: 150, Resize: "crop"}}, ShortURLLength: 23, ShortURLLengthHTTPS: 23, NonUsernamePaths: []string{"about"}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, status)
 }

--- a/twitter/config_test.go
+++ b/twitter/config_test.go
@@ -1,0 +1,26 @@
+package twitter
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigService_Get(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/help/configuration.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, ` {"characters_reserved_per_media": 24, "dm_text_character_limit": 10000, "max_media_per_upload": 1, "photo_size_limit": 3145728, "photo_sizes": { "large": { "h": 2048, "resize": "fit", "w": 1024 }, "medium": { "h": 1200, "resize": "fit", "w": 600 }, "small": { "h": 480, "resize": "fit", "w": 340 }, "thumb": { "h": 150, "resize": "crop", "w": 150 } }, "short_url_length": 23, "short_url_length_https": 23, "non_username_paths": [ "about" ] }`)
+	})
+
+	client := NewClient(httpClient)
+	status, _, err := client.Config.Get()
+	expected := &Config{CharactersReservedPerMedia: 24, DMTextCharacterLimit: 10000, MaxMediaPerUpload: 1, PhotoSizeLimit: 3145728, PhotoSizes: &PhotoSizes{Large: &SinglePhotoSize{Height: 2048, Width: 1024, Resize: "fit"}, Medium: &SinglePhotoSize{Height: 1200, Width: 600, Resize: "fit"}, Small: &SinglePhotoSize{Height: 480, Width: 340, Resize: "fit"}, Thumb: &SinglePhotoSize{Height: 150, Width: 150, Resize: "crop"}}, ShortURLLength: 23, ShortURLLengthHttps: 23, NonUsernamePaths: []string{"about"}}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, status)
+}

--- a/twitter/media.go
+++ b/twitter/media.go
@@ -1,0 +1,183 @@
+package twitter
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// The size of a chunk to upload. There isn't any set size, so we
+// choose 1M for convenience.
+const chunkSize = 1024 * 1024
+
+// This should really be fetched from the status endpoint, but the
+// docs say 15M so we'll go with that.
+const maxSize = 15 * 1024 * 1024
+
+type MediaService struct {
+	sling *sling.Sling
+}
+
+func newMediaService(sling *sling.Sling) *MediaService {
+	return &MediaService{
+		sling: sling.Path("media/"),
+	}
+}
+
+type mediaInitResult struct {
+	MediaID          int64  `json:"media_id"`
+	MediaIDString    string `json:"media_id_string"`
+	Size             int    `json:"size"`
+	ExpiresAfterSecs int    `json:"expires_after_secs"`
+}
+
+type mediaInitParams struct {
+	Command    string `url:"command"`
+	TotalBytes int    `url:"total_bytes"`
+	MediaType  string `url:"media_type"`
+}
+
+type mediaAppendParams struct {
+	Command      string `url:"command"`
+	MediaData    string `url:"media_data"`
+	MediaID      int64  `url:"media_id"`
+	SegmentIndex int    `url:"segment_index"`
+}
+
+type MediaVideoInfo struct {
+	VideoType string `json:"video_type"`
+}
+
+type MediaProcessingInfo struct {
+	State           string                `json:"state"`
+	CheckAfterSecs  int                   `json:"check_after_secs"`
+	ProgressPercent int                   `json:"progress_percent"`
+	Error           *MediaProcessingError `json:"error"`
+}
+
+type MediaProcessingError struct {
+	Code    int    `json:"code"`
+	Name    string `json:"name"`
+	Message string `json:"message"`
+}
+
+// MediaUploadResult holds information about a successfully completed
+// media upload. Note that successful uploads may not be immediately
+// usable if twitter is doing background processing on the uploaded
+// media.
+type MediaUploadResult struct {
+	MediaID          int64                `json:"media_id"`
+	MediaIDString    string               `json:"media_id_string"`
+	Size             int                  `json:"size"`
+	ExpiresAfterSecs int                  `json:"expires_after_secs"`
+	Video            *MediaVideoInfo      `json:"video"`
+	ProcessingInfo   *MediaProcessingInfo `json:"processing_info"`
+}
+
+type mediaFinalizeParams struct {
+	Command string `url:"command"`
+	MediaID int64  `url:"media_id"`
+}
+
+// Upload sends a piece of media to twitter. You must provide a byte
+// slice containing the file contents and the MIME type of the
+// file.
+//
+// This is a potentially asynchronous call, as some file types require
+// extra processing by twitter. In those cases the returned
+// MediaFinalizeResult will have the ProcessingInfo field set, and you
+// can periodically poll Status with the MediaID to get the status of
+// the upload.
+func (m *MediaService) Upload(media []byte, mediaType string) (*MediaUploadResult, *http.Response, error) {
+
+	if len(media) > maxSize {
+		return nil, nil, fmt.Errorf("file size of %v exceeds twitter maximum %v", len(media), maxSize)
+	}
+
+	params := &mediaInitParams{
+		Command:    "INIT",
+		TotalBytes: len(media),
+		MediaType:  mediaType,
+	}
+	res := new(mediaInitResult)
+	apiError := new(APIError)
+
+	resp, err := m.sling.New().Post("upload.json").BodyForm(params).Receive(res, apiError)
+
+	if relevantError(err, *apiError) != nil {
+		return nil, resp, relevantError(err, *apiError)
+	}
+
+	mediaID := res.MediaID
+
+	segments := int(len(media) / chunkSize)
+	for segment := 0; segment <= segments; segment++ {
+		start := segment * chunkSize
+		end := (segment + 1) * chunkSize
+		if end > len(media) {
+			end = len(media)
+		}
+		chunk := media[start:end]
+
+		appendParams := &mediaAppendParams{
+			Command:      "APPEND",
+			MediaID:      mediaID,
+			MediaData:    base64.StdEncoding.EncodeToString(chunk),
+			SegmentIndex: segment,
+		}
+
+		resp, err = m.sling.New().Post("upload.json").BodyForm(appendParams).Receive(nil, apiError)
+
+		if relevantError(err, *apiError) != nil {
+			return nil, resp, relevantError(err, *apiError)
+		}
+	}
+
+	finalizeParams := &mediaFinalizeParams{
+		Command: "FINALIZE",
+		MediaID: mediaID,
+	}
+	finalizeRes := new(MediaUploadResult)
+
+	resp, err = m.sling.New().Post("upload.json").BodyForm(finalizeParams).Receive(finalizeRes, apiError)
+
+	if relevantError(err, *apiError) != nil {
+		return nil, resp, relevantError(err, *apiError)
+	}
+
+	return finalizeRes, resp, nil
+}
+
+// MediaStatusResult holds information about the current status of a
+// piece of media.
+type MediaStatusResult struct {
+	MediaID          int                  `json:"media_id"`
+	MediaIDString    string               `json:"media_id_string"`
+	ExpiresAfterSecs int                  `json:"expires_after_secs"`
+	ProcessingInfo   *MediaProcessingInfo `json:"processing_info"`
+	Video            *MediaVideoInfo      `json:"video"`
+}
+
+type mediaStatusParams struct {
+	Command string `url:"command"`
+	MediaID int64  `url:"media_id"`
+}
+
+// Status returns the current status of the media specified by the
+// media ID. It's only valid to call Status on a request where the
+// Upload call returned something in ProcessingInfo.
+// https://developer.twitter.com/en/docs/media/upload-media/api-reference/get-media-upload-status
+func (m *MediaService) Status(mediaID int64) (*MediaStatusResult, *http.Response, error) {
+	params := &mediaStatusParams{
+		MediaID: mediaID,
+		Command: "STATUS",
+	}
+
+	status := new(MediaStatusResult)
+	apiError := new(APIError)
+	resp, err := m.sling.New().Get("upload.json").QueryStruct(params).Receive(status, apiError)
+	return status, resp, relevantError(err, *apiError)
+
+}

--- a/twitter/media.go
+++ b/twitter/media.go
@@ -16,6 +16,7 @@ const chunkSize = 1024 * 1024
 // docs say 15M so we'll go with that.
 const maxSize = 15 * 1024 * 1024
 
+// MediaService provides methods for accessing twitter media APIs.
 type MediaService struct {
 	sling *sling.Sling
 }
@@ -46,10 +47,12 @@ type mediaAppendParams struct {
 	SegmentIndex int    `url:"segment_index"`
 }
 
+// MediaVideoInfo holds information about media identified as videos.
 type MediaVideoInfo struct {
 	VideoType string `json:"video_type"`
 }
 
+// MediaProcessingInfo holds information about pending media uploads.
 type MediaProcessingInfo struct {
 	State           string                `json:"state"`
 	CheckAfterSecs  int                   `json:"check_after_secs"`
@@ -57,6 +60,8 @@ type MediaProcessingInfo struct {
 	Error           *MediaProcessingError `json:"error"`
 }
 
+// MediaProcessingError holds information about pending media
+// processing failures.
 type MediaProcessingError struct {
 	Code    int    `json:"code"`
 	Name    string `json:"name"`

--- a/twitter/media_test.go
+++ b/twitter/media_test.go
@@ -1,0 +1,171 @@
+package twitter
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Fake a server to handle the upload requests. Failure triggers:
+// START:
+//    11 byte images fail
+// APPEND:
+//    17 byte images fail
+// FINALIZE
+//    23 byte images fail
+
+func uploadResponseFunc(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseForm()
+	if err != nil {
+	}
+	w.Header().Set("Content-Type", "application/json")
+
+	rt := r.FormValue("command")
+	log.Printf("command is %q", rt)
+	// No command means it's a bad request
+	if rt == "" {
+		log.Printf("no command")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	switch rt {
+	case "INIT":
+		tb := r.FormValue("total_bytes")
+		// 11 byte requests trigger the
+		if tb == "11" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		log.Printf("tb is %q", tb)
+		fmt.Fprintf(w, `{"media_id": %v, "media_id_string": "%v", "size": %v, "expires_after_secs": 86400}`, tb, tb, tb)
+	case "APPEND":
+		mid := r.FormValue("media_id")
+		if mid == "17" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	case "FINALIZE":
+		mid := r.FormValue("media_id")
+		if mid == "23" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintf(w, `{"media_id": %v, "media_id_string": "%v", "size": %v, "expires_after_secs": 86400}`, mid, mid, mid)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, `{"status":"bad"}`)
+	}
+}
+
+func TestMediaService_Upload(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		filetype string
+		wantErr  bool
+		want     *MediaUploadResult
+	}{
+		{
+			name:     "small OK",
+			data:     []byte{1, 2, 3},
+			filetype: "image/jpeg",
+			want: &MediaUploadResult{
+				MediaID:          3,
+				MediaIDString:    "3",
+				Size:             3,
+				ExpiresAfterSecs: 86400,
+			},
+		},
+		{
+			name:     "multipart OK",
+			data:     bytes.Repeat([]byte{50}, chunkSize*4),
+			filetype: "video/mp4",
+			want: &MediaUploadResult{
+				MediaID:          chunkSize * 4,
+				MediaIDString:    fmt.Sprintf("%v", chunkSize*4),
+				Size:             chunkSize * 4,
+				ExpiresAfterSecs: 86400,
+			},
+		},
+		{
+			name:     "start fails",
+			data:     []byte{11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11},
+			filetype: "video/mp4",
+			wantErr:  true,
+		},
+		{
+			name:     "big fail",
+			data:     bytes.Repeat([]byte{10}, maxSize+20),
+			filetype: "image/gif",
+			wantErr:  true,
+		},
+		{
+			name:     "append fails",
+			data:     bytes.Repeat([]byte{17}, 17),
+			filetype: "image/jpeg",
+			wantErr:  true,
+		},
+		{
+			name:     "finalize fails",
+			data:     bytes.Repeat([]byte{23}, 23),
+			filetype: "image/gif",
+			wantErr:  true,
+		},
+	}
+
+	httpClient, mux, server := testServer()
+	defer server.Close()
+	mux.HandleFunc("/1.1/media/upload.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		uploadResponseFunc(w, r)
+	})
+
+	client := NewClient(httpClient)
+
+	for _, test := range tests {
+		resp, _, err := client.Media.Upload(test.data, test.filetype)
+		if err != nil {
+			if !test.wantErr {
+				t.Errorf("Media.Upload(%v): err: %v", test.name, err)
+			}
+			continue
+		}
+		if err == nil {
+			assert.Equal(t, test.want, resp)
+		}
+
+	}
+
+}
+
+func TestMediaService_Status(t *testing.T) {
+
+	httpClient, mux, server := testServer()
+	defer server.Close()
+	mux.HandleFunc("/1.1/media/upload.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"media_id": 123, "media_id_string": "123", "expires_after_secs": 86400, "processing_info": {"state": "succeeded", "progress_percent": 100}}`)
+	})
+
+	expected := &MediaStatusResult{
+		MediaID:          123,
+		MediaIDString:    "123",
+		ExpiresAfterSecs: 86400,
+		ProcessingInfo: &MediaProcessingInfo{
+			State:           "succeeded",
+			ProgressPercent: 100,
+		},
+	}
+
+	client := NewClient(httpClient)
+	result, _, err := client.Media.Status(123)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}

--- a/twitter/twitter.go
+++ b/twitter/twitter.go
@@ -7,6 +7,7 @@ import (
 )
 
 const twitterAPI = "https://api.twitter.com/1.1/"
+const twitterUpload = "https://upload.twitter.com/1.1/"
 
 // Client is a Twitter client for making Twitter API requests.
 type Client struct {
@@ -20,6 +21,7 @@ type Client struct {
 	Friends        *FriendService
 	Friendships    *FriendshipService
 	Lists          *ListsService
+	Media          *MediaService
 	RateLimits     *RateLimitService
 	Search         *SearchService
 	PremiumSearch  *PremiumSearchService
@@ -33,6 +35,7 @@ type Client struct {
 // NewClient returns a new Client.
 func NewClient(httpClient *http.Client) *Client {
 	base := sling.New().Client(httpClient).Base(twitterAPI)
+	upload := sling.New().Client(httpClient).Base(twitterUpload)
 	return &Client{
 		sling:          base,
 		Accounts:       newAccountService(base.New()),
@@ -43,6 +46,7 @@ func NewClient(httpClient *http.Client) *Client {
 		Friends:        newFriendService(base.New()),
 		Friendships:    newFriendshipService(base.New()),
 		Lists:          newListService(base.New()),
+		Media:          newMediaService(upload.New()),
 		RateLimits:     newRateLimitService(base.New()),
 		Search:         newSearchService(base.New()),
 		PremiumSearch:  newPremiumSearchService(base.New()),

--- a/twitter/twitter.go
+++ b/twitter/twitter.go
@@ -13,6 +13,7 @@ type Client struct {
 	sling *sling.Sling
 	// Twitter API Services
 	Accounts       *AccountService
+	Config         *ConfigService
 	DirectMessages *DirectMessageService
 	Favorites      *FavoriteService
 	Followers      *FollowerService
@@ -35,6 +36,7 @@ func NewClient(httpClient *http.Client) *Client {
 	return &Client{
 		sling:          base,
 		Accounts:       newAccountService(base.New()),
+		Config:         newConfigService(base.New()),
 		DirectMessages: newDirectMessageService(base.New()),
 		Favorites:      newFavoriteService(base.New()),
 		Followers:      newFollowerService(base.New()),


### PR DESCRIPTION
This wraps the media upload and upload status checking API calls so clients can upload media to twitter.