### PR TITLE
Add `Retweeters` support for retweeters ids

### DIFF
--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -257,6 +257,31 @@ func (s *StatusService) Retweets(id int64, params *StatusRetweetsParams) ([]Twee
 	return *tweets, resp, relevantError(err, *apiError)
 }
 
+// StatusRetweeterParams are the parameters for StatusService.Retweeters.
+type StatusRetweeterParams struct {
+	ID     int64 `url:"id,omitempty"`
+	Count  int   `url:"count,omitempty"`
+	Cursor int64 `url:"cursor,omitempty"`
+}
+
+// RetweeterIDs is a cursored collection of User IDs that retweeted a Tweet.
+type RetweeterIDs struct {
+	IDs               []int64 `json:"ids"`
+	PreviousCursor    int64   `json:"previous_cursor"`
+	PreviousCursorStr string  `json:"previous_cursor_str"`
+	NextCursor        int64   `json:"next_cursor"`
+	NextCursorStr     string  `json:"next_cursor_str"`
+}
+
+// Retweeters return the retweeters of a specific tweet.
+// https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweeters-ids
+func (s *StatusService) Retweeters(params *StatusRetweeterParams) (*RetweeterIDs, *http.Response, error) {
+	retweeters := new(RetweeterIDs)
+	apiError := new(APIError)
+	resp, err := s.sling.Get("retweeters/ids.json").QueryStruct(params).Receive(retweeters, apiError)
+	return retweeters, resp, relevantError(err, *apiError)
+}
+
 // StatusDestroyParams are the parameters for StatusService.Destroy
 type StatusDestroyParams struct {
 	ID        int64  `url:"id,omitempty"`
@@ -314,30 +339,4 @@ func (s *StatusService) OEmbed(params *StatusOEmbedParams) (*OEmbedTweet, *http.
 	apiError := new(APIError)
 	resp, err := s.sling.New().Get("oembed.json").QueryStruct(params).Receive(oEmbedTweet, apiError)
 	return oEmbedTweet, resp, relevantError(err, *apiError)
-}
-
-// StatusRetweeterParams are the parameters for StatusService.Retweeters.
-type StatusRetweeterParams struct {
-	ID           int64  `url:"id,omitempty"`
-	Cursor       int64  `url:"cursor,omitempty"`
-	Count        int    `url:"count,omitempty"`
-	StringifyIDs string `url:"stringify_ids,omitempty"`
-}
-
-// Retweeter represents a Tweet in oEmbed format.
-type Retweeter struct {
-	PreviousCursor    int64    `json:"previous_cursor"`
-	PreviousCursorStr string   `json:"previous_cursor_str"`
-	IDs               []string `json:"ids"`
-	NextCursor        int64    `json:"next_cursor"`
-	NextCursorStr     string   `json:"next_cursor_str"`
-}
-
-// Retweeters return the retweeters of a specific tweet.
-// https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweeters-ids
-func (s *StatusService) Retweeters(params *StatusRetweeterParams) (*Retweeter, *http.Response, error) {
-	retweeters := new(Retweeter)
-	apiError := new(APIError)
-	resp, err := s.sling.Get("retweeter/ids.json").QueryStruct(params).Receive(retweeters, apiError)
-	return retweeters, resp, relevantError(err, *apiError)
 }

--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -315,3 +315,29 @@ func (s *StatusService) OEmbed(params *StatusOEmbedParams) (*OEmbedTweet, *http.
 	resp, err := s.sling.New().Get("oembed.json").QueryStruct(params).Receive(oEmbedTweet, apiError)
 	return oEmbedTweet, resp, relevantError(err, *apiError)
 }
+
+// StatusRetweeterParams are the parameters for StatusService.Retweeters.
+type StatusRetweeterParams struct {
+	ID           int64  `url:"id,omitempty"`
+	Cursor       int64  `url:"cursor,omitempty"`
+	Count        int    `url:"count,omitempty"`
+	StringifyIDs string `url:"stringify_ids,omitempty"`
+}
+
+// Retweeter represents a Tweet in oEmbed format.
+type Retweeter struct {
+	PreviousCursor    int64    `json:"previous_cursor"`
+	PreviousCursorStr string   `json:"previous_cursor_str"`
+	IDs               []string `json:"ids"`
+	NextCursor        int64    `json:"next_cursor"`
+	NextCursorStr     string   `json:"next_cursor_str"`
+}
+
+// Retweeters return the retweeters of a specific tweet.
+// https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweeters-ids
+func (s *StatusService) Retweeters(params *StatusRetweeterParams) (*Retweeter, *http.Response, error) {
+	retweeters := new(Retweeter)
+	apiError := new(APIError)
+	resp, err := s.sling.Get("retweeter/ids.json").QueryStruct(params).Receive(retweeters, apiError)
+	return retweeters, resp, relevantError(err, *apiError)
+}

--- a/twitter/statuses_test.go
+++ b/twitter/statuses_test.go
@@ -273,3 +273,41 @@ func TestStatusService_OEmbed(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, oembed)
 }
+
+func TestStatusService_Retweeters(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/statuses/retweeter/ids.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"id": "10", "cursor": "11", "count": "100", "stringify_ids": "10"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+    "previous_cursor": 11,
+    "ids": [
+        "1382021622"
+    ],
+    "previous_cursor_str": "11",
+    "next_cursor": 22,
+    "next_cursor_str": "22"
+}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &StatusRetweeterParams{
+		ID:           10,
+		Cursor:       11,
+		Count:        100,
+		StringifyIDs: "10",
+	}
+	tweets, _, err := client.Statuses.Retweeters(params)
+	expected := &Retweeter{
+		PreviousCursor:    11,
+		IDs:               []string{"1382021622"},
+		PreviousCursorStr: "11",
+		NextCursor:        22,
+		NextCursorStr:     "22",
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, tweets)
+}


### PR DESCRIPTION
Hi Dalton,

I have added a `Retweeters` to support [Statuses.Retweeters](https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweeters-ids).
It contains `Retweeters` function in `statuses.go` to get user_ids which retweet specific tweet.
I have also added unit tests in the style of exist tests to test the functions.

It's my pleasure for your pulling.

Shuxiao.