### PR TITLE
Update fields in StatusUpdateParams

### DIFF
--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -159,16 +159,21 @@ func (s *StatusService) Lookup(ids []int64, params *StatusLookupParams) ([]Tweet
 
 // StatusUpdateParams are the parameters for StatusService.Update
 type StatusUpdateParams struct {
-	Status             string   `url:"status,omitempty"`
-	InReplyToStatusID  int64    `url:"in_reply_to_status_id,omitempty"`
-	PossiblySensitive  *bool    `url:"possibly_sensitive,omitempty"`
-	Lat                *float64 `url:"lat,omitempty"`
-	Long               *float64 `url:"long,omitempty"`
-	PlaceID            string   `url:"place_id,omitempty"`
-	DisplayCoordinates *bool    `url:"display_coordinates,omitempty"`
-	TrimUser           *bool    `url:"trim_user,omitempty"`
-	MediaIds           []int64  `url:"media_ids,omitempty,comma"`
-	TweetMode          string   `url:"tweet_mode,omitempty"`
+	Status                    string   `url:"status,omitempty"`
+	InReplyToStatusID         int64    `url:"in_reply_to_status_id,omitempty"`
+	PossiblySensitive         *bool    `url:"possibly_sensitive,omitempty"`
+	Lat                       *float64 `url:"lat,omitempty"`
+	Long                      *float64 `url:"long,omitempty"`
+	PlaceID                   string   `url:"place_id,omitempty"`
+	DisplayCoordinates        *bool    `url:"display_coordinates,omitempty"`
+	TrimUser                  *bool    `url:"trim_user,omitempty"`
+	MediaIds                  []int64  `url:"media_ids,omitempty,comma"`
+	AutoPopulateReplyMetadata *bool    `url:"auto_populate_reply_metadata,omitempty"`
+	ExcludeReplyUserIds       []int64  `url:"exclude_reply_user_ids,comma,omitempty"`
+	AttachmentURL             string   `url:"attachment_url,omitempty"`
+	EnableDmcommands          *bool    `url:"enable_dmcommands,omitempty"`
+	FailDmcommands            *bool    `url:"fail_dmcommands,omitempty"`
+	CardURI                   string   `url:"card_uri,omitempty"`
 }
 
 // Update updates the user's status, also known as Tweeting.


### PR DESCRIPTION
I updated fields in StatusUpdateParams for the latest`POST statuses/update` API.

These fields can be found here.
https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update

### Remove
- TweetMode

### Add
- AutoPopulateReplyMetadata
- ExcludeReplyUserIds
- AttachmentURL
- FailDmcommands
- CardURI