### PR TITLE
Added AccountService.UpdateProfile()

### DIFF
--- a/twitter/accounts.go
+++ b/twitter/accounts.go
@@ -35,3 +35,26 @@ func (s *AccountService) VerifyCredentials(params *AccountVerifyParams) (*User, 
 	resp, err := s.sling.New().Get("verify_credentials.json").QueryStruct(params).Receive(user, apiError)
 	return user, resp, relevantError(err, *apiError)
 }
+
+// UpdateProfileParams are the params for AccountService.UpdateProfile.
+type UpdateProfileParams struct {
+	Name            string `url:"name,omitempty"`
+	URL             string `url:"url,omitempty"`
+	Location        string `url:"location,omitempty"`
+	Description     string `url:"description,omitempty"`
+	IncludeEntities *bool  `url:"include_entities,omitempty"`
+	SkipStatus      *bool  `url:"skip_status,omitempty"`
+}
+
+// UpdateProfile updates the user's profile
+// Requires a user auth context.
+// https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile
+func (s *AccountService) UpdateProfile(params *UpdateProfileParams) (*User, *http.Response, error) {
+	if params == nil {
+		params = &UpdateProfileParams{}
+	}
+	user := new(User)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Post("update_profile.json").BodyForm(params).Receive(user, apiError)
+	return user, resp, relevantError(err, *apiError)
+}

--- a/twitter/accounts_test.go
+++ b/twitter/accounts_test.go
@@ -25,3 +25,23 @@ func TestAccountService_VerifyCredentials(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, user)
 }
+
+func TestAccountService_UpdateProfile(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/account/update_profile.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertQuery(t, map[string]string{}, r)
+		assertPostForm(t, map[string]string{"name": "John Smith", "url": "example.com", "location": "Cupertino, CA", "description": "This is a description"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"screen_name": "johnsmith52", "name": "John Smith", "url": "example.com", "location": "Cupertino, CA", "description": "This is a description"}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &UpdateProfileParams{Name: "John Smith", URL: "example.com", Location: "Cupertino, CA", Description: "This is a description"}
+	tweet, _, err := client.Accounts.UpdateProfile(params)
+	expected := &User{ScreenName: "johnsmith52", Name: "John Smith", URL: "example.com", Location: "Cupertino, CA", Description: "This is a description"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, tweet)
+}


### PR DESCRIPTION
Added support for updating profile as per https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile