### PR TITLE
Added support for statuses/lookup map param

### DIFF
--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -177,6 +177,7 @@ func (s *StatusService) Lookup(ids []int64, params *StatusLookupParams) ([]Tweet
 			for i, id := range params.ID {
 				if strconv.FormatInt(id, 10) == k {
 					tweets[i] = v
+					break
 				}
 			}
 		}


### PR DESCRIPTION
Previously setting the "map" param to true broke because of the different response format.