### PR TITLE
Change follow type from string to int64

### DIFF
--- a/twitter/streams.go
+++ b/twitter/streams.go
@@ -40,7 +40,7 @@ func newStreamService(client *http.Client, sling *sling.Sling) *StreamService {
 // StreamFilterParams are parameters for StreamService.Filter.
 type StreamFilterParams struct {
 	FilterLevel   string   `url:"filter_level,omitempty"`
-	Follow        []string `url:"follow,omitempty,comma"`
+	Follow        []int64  `url:"follow,omitempty,comma"`
 	Language      []string `url:"language,omitempty,comma"`
 	Locations     []string `url:"locations,omitempty,comma"`
 	StallWarnings *bool    `url:"stall_warnings,omitempty"`
@@ -97,7 +97,7 @@ func (srv *StreamService) User(params *StreamUserParams) (*Stream, error) {
 // StreamSiteParams are the parameters for StreamService.Site.
 type StreamSiteParams struct {
 	FilterLevel   string   `url:"filter_level,omitempty"`
-	Follow        []string `url:"follow,omitempty,comma"`
+	Follow        []int64  `url:"follow,omitempty,comma"`
 	Language      []string `url:"language,omitempty,comma"`
 	Replies       string   `url:"replies,omitempty"`
 	StallWarnings *bool    `url:"stall_warnings,omitempty"`

--- a/twitter/streams_test.go
+++ b/twitter/streams_test.go
@@ -273,7 +273,7 @@ func TestStream_Site(t *testing.T) {
 	demux := newCounterDemux(counts)
 	client := NewClient(httpClient)
 	streamSiteParams := &StreamSiteParams{
-		Follow: []string{"666024290140217347", "666024290140217349"},
+		Follow: []int64{666024290140217347, 666024290140217349},
 	}
 	stream, err := client.Streams.Site(streamSiteParams)
 	// assert that the expected messages are received


### PR DESCRIPTION
`StreamFilterParams` and `StreamSiteParams` both take a Follow parameter which is an array of user IDs. User IDs are of type `int64`. It's logical for Follow to be an array of `int64` rather than `string`.