### PR TITLE
Amend oembed param url tags for hide_thread and omit_script

### DIFF
--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -301,8 +301,8 @@ type StatusOEmbedParams struct {
 	Align      string `url:"align,omitempty"`
 	MaxWidth   int64  `url:"maxwidth,omitempty"`
 	HideMedia  *bool  `url:"hide_media,omitempty"`
-	HideThread *bool  `url:"hide_media,omitempty"`
-	OmitScript *bool  `url:"hide_media,omitempty"`
+	HideThread *bool  `url:"hide_thread,omitempty"`
+	OmitScript *bool  `url:"omit_script,omitempty"`
 	WidgetType string `url:"widget_type,omitempty"`
 	HideTweet  *bool  `url:"hide_tweet,omitempty"`
 }


### PR DESCRIPTION
The URL tags present on the StatusOEmbedParams struct for the HideThread and OmitScript field were both hide_media which results in unexpected behaviour when trying to use these options.

With this PR I have set these to the correct URL tags, as outlined here: https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/oembed-api.

Thanks for your work and effort in maintaining this client!