### PR TITLE
Add support for fetching extended tweets in lists

### DIFF
--- a/twitter/lists.go
+++ b/twitter/lists.go
@@ -201,6 +201,7 @@ type ListsStatusesParams struct {
 	Count           int    `url:"count,omitempty"`
 	IncludeEntities *bool  `url:"include_entities,omitempty"`
 	IncludeRetweets *bool  `url:"include_rts,omitempty"`
+	TweetMode       string `url:"tweet_mode,omitempty"`
 }
 
 // Statuses returns a timeline of tweets authored by members of the specified list.


### PR DESCRIPTION
While fetching tweets from Twitter lists, I realized that the current version of the parameters struct does not allow for requesting `extended` tweet text support. The result is that all tweets longer than 140 chars end up being cut at that mark.

I wasn't really sure, whether the lists API supports that option, so I forked the repo, added it in and tested it out. I started receiving the full text right away. 

We are currently pointing our app's build at my fork, but it would be great to accept this change in the official repo.

Thanks!
