### PR TITLE
feat: add auto_populate_reply_metadata

### DIFF
--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -159,16 +159,17 @@ func (s *StatusService) Lookup(ids []int64, params *StatusLookupParams) ([]Tweet
 
 // StatusUpdateParams are the parameters for StatusService.Update
 type StatusUpdateParams struct {
-	Status             string   `url:"status,omitempty"`
-	InReplyToStatusID  int64    `url:"in_reply_to_status_id,omitempty"`
-	PossiblySensitive  *bool    `url:"possibly_sensitive,omitempty"`
-	Lat                *float64 `url:"lat,omitempty"`
-	Long               *float64 `url:"long,omitempty"`
-	PlaceID            string   `url:"place_id,omitempty"`
-	DisplayCoordinates *bool    `url:"display_coordinates,omitempty"`
-	TrimUser           *bool    `url:"trim_user,omitempty"`
-	MediaIds           []int64  `url:"media_ids,omitempty,comma"`
-	TweetMode          string   `url:"tweet_mode,omitempty"`
+	Status                    string   `url:"status,omitempty"`
+	InReplyToStatusID         int64    `url:"in_reply_to_status_id,omitempty"`
+	AutoPopulateReplyMetadata *bool    `url:"auto_populate_reply_metadata,omitempty"`
+	PossiblySensitive         *bool    `url:"possibly_sensitive,omitempty"`
+	Lat                       *float64 `url:"lat,omitempty"`
+	Long                      *float64 `url:"long,omitempty"`
+	PlaceID                   string   `url:"place_id,omitempty"`
+	DisplayCoordinates        *bool    `url:"display_coordinates,omitempty"`
+	TrimUser                  *bool    `url:"trim_user,omitempty"`
+	MediaIds                  []int64  `url:"media_ids,omitempty,comma"`
+	TweetMode                 string   `url:"tweet_mode,omitempty"`
 }
 
 // Update updates the user's status, also known as Tweeting.


### PR DESCRIPTION
Hi @dghubble,

this PR add support for `auto_populate_reply_metadata` in the `StatusUpdateParams`struct.

From the [docs](https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update):

> If set to true and used with in_reply_to_status_id, leading @mentions will be looked up from the original Tweet, and added to the new Tweet from there. This wil append @mentions into the metadata of an extended Tweet as a reply chain grows, until the limit on @mentions is reached.

Would be cool to get this into your library.