### PR TITLE
Add AccountService UpdateProfile

### DIFF
--- a/twitter/accounts.go
+++ b/twitter/accounts.go
@@ -35,3 +35,24 @@ func (s *AccountService) VerifyCredentials(params *AccountVerifyParams) (*User, 
 	resp, err := s.sling.New().Get("verify_credentials.json").QueryStruct(params).Receive(user, apiError)
 	return user, resp, relevantError(err, *apiError)
 }
+
+// AccountUpdateProfileParams are the params for AccountService.UpdateProfile.
+type AccountUpdateProfileParams struct {
+	Name            string `url:"name,omitempty"`
+	URL             string `url:"url,omitempty"`
+	Location        string `url:"location,omitempty"`
+	Description     string `url:"description,omitempty"`
+	IncludeEntities *bool  `url:"include_entities,omitempty"`
+	SkipStatus      *bool  `url:"skip_status,omitempty"`
+}
+
+// UpdateProfile updates the account profile with specified fields and returns
+// the User.
+// Requires a user auth context.
+// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile
+func (s *AccountService) UpdateProfile(params *AccountUpdateProfileParams) (*User, *http.Response, error) {
+	user := new(User)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Post("update_profile.json").QueryStruct(params).Receive(user, apiError)
+	return user, resp, relevantError(err, *apiError)
+}

--- a/twitter/accounts_test.go
+++ b/twitter/accounts_test.go
@@ -25,3 +25,21 @@ func TestAccountService_VerifyCredentials(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, user)
 }
+func TestAccountService_UpdateProfile(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/1.1/account/update_profile.json", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertQuery(t, map[string]string{"location": "anywhere"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"name": "xkcdComic", "location":"anywhere"}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &AccountUpdateProfileParams{Location: "anywhere"}
+	user, _, err := client.Accounts.UpdateProfile(params)
+	expected := &User{Name: "xkcdComic", Location: "anywhere"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, user)
+}


### PR DESCRIPTION
* POST to `account/update_profile.json` to set specified user account values
* [Docs](https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile)

Closes #153 #158