### PR TITLE
Add missing fields to StatusUpdateParams

### DIFF
--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -162,14 +162,18 @@ type StatusUpdateParams struct {
 	Status                    string   `url:"status,omitempty"`
 	InReplyToStatusID         int64    `url:"in_reply_to_status_id,omitempty"`
 	AutoPopulateReplyMetadata *bool    `url:"auto_populate_reply_metadata,omitempty"`
+	ExcludeReplyUserIds       []int64  `url:"exclude_reply_user_ids,comma,omitempty"`
+	AttachmentURL             string   `url:"attachment_url,omitempty"`
+	MediaIds                  []int64  `url:"media_ids,omitempty,comma"`
 	PossiblySensitive         *bool    `url:"possibly_sensitive,omitempty"`
 	Lat                       *float64 `url:"lat,omitempty"`
 	Long                      *float64 `url:"long,omitempty"`
 	PlaceID                   string   `url:"place_id,omitempty"`
 	DisplayCoordinates        *bool    `url:"display_coordinates,omitempty"`
 	TrimUser                  *bool    `url:"trim_user,omitempty"`
-	MediaIds                  []int64  `url:"media_ids,omitempty,comma"`
-	TweetMode                 string   `url:"tweet_mode,omitempty"`
+	CardURI                   string   `url:"card_uri,omitempty"`
+	// Deprecated
+	TweetMode string `url:"tweet_mode,omitempty"`
 }
 
 // Update updates the user's status, also known as Tweeting.


### PR DESCRIPTION
* Add ExcludeReplyUserIDs, AttachmentURL, and CardURI fields to the StatusUpdateParams
* Mark TweetMode as deprecated

Close #151
Rel: https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update