### PR TITLE
Fix Client to provide BlockService as Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ go-twitter is a Go client library for the [Twitter API](https://dev.twitter.com/
 
 * Twitter REST API:
     * Accounts
+    * Blocks
     * DirectMessageEvents
     * Favorites
     * Friends

--- a/twitter/block.go
+++ b/twitter/block.go
@@ -1,8 +1,9 @@
 package twitter
 
 import (
-	"github.com/dghubble/sling"
 	"net/http"
+
+	"github.com/dghubble/sling"
 )
 
 // BlockService provides methods for blocking specific user.
@@ -21,11 +22,11 @@ func newBlockService(sling *sling.Sling) *BlockService {
 type BlockCreateParams struct {
 	ScreenName      string `url:"screen_name,omitempty,comma"`
 	UserID          int64  `url:"user_id,omitempty,comma"`
-	IncludeEntities *bool  `url:"include_entities,omitempty"` // whether 'status' should include entities
+	IncludeEntities *bool  `url:"include_entities,omitempty"`
 	SkipStatus      *bool  `url:"skip_status,omitempty"`
 }
 
-// Create a block for specific user, return the user blocked as Entity.
+// Create blocks a specific user and returns the blocked user.
 // https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-blocks-create
 func (s *BlockService) Create(params *BlockCreateParams) (User, *http.Response, error) {
 	users := new(User)
@@ -38,11 +39,11 @@ func (s *BlockService) Create(params *BlockCreateParams) (User, *http.Response, 
 type BlockDestroyParams struct {
 	ScreenName      string `url:"screen_name,omitempty,comma"`
 	UserID          int64  `url:"user_id,omitempty,comma"`
-	IncludeEntities *bool  `url:"include_entities,omitempty"` // whether 'status' should include entities
+	IncludeEntities *bool  `url:"include_entities,omitempty"`
 	SkipStatus      *bool  `url:"skip_status,omitempty"`
 }
 
-// Destroy the block for specific user, return the user unblocked as Entity.
+// Destroy blocks a specific user and returns the unblocked user.
 // https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-blocks-destroy
 func (s *BlockService) Destroy(params *BlockDestroyParams) (User, *http.Response, error) {
 	users := new(User)

--- a/twitter/block_test.go
+++ b/twitter/block_test.go
@@ -2,9 +2,10 @@ package twitter
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBlockService_CreateService(t *testing.T) {
@@ -19,7 +20,7 @@ func TestBlockService_CreateService(t *testing.T) {
 	})
 
 	client := NewClient(httpClient)
-	users, _, err := client.Block.Create(&BlockCreateParams{ScreenName: "golang"})
+	users, _, err := client.Blocks.Create(&BlockCreateParams{ScreenName: "golang"})
 	expected := User{ScreenName: "golang"}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, users)
@@ -37,7 +38,7 @@ func TestBlockService_DestroyService(t *testing.T) {
 	})
 
 	client := NewClient(httpClient)
-	users, _, err := client.Block.Destroy(&BlockDestroyParams{ScreenName: "golang"})
+	users, _, err := client.Blocks.Destroy(&BlockDestroyParams{ScreenName: "golang"})
 	expected := User{ScreenName: "golang"}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, users)

--- a/twitter/twitter.go
+++ b/twitter/twitter.go
@@ -13,7 +13,7 @@ type Client struct {
 	sling *sling.Sling
 	// Twitter API Services
 	Accounts       *AccountService
-	Block          *BlockService
+	Blocks         *BlockService
 	DirectMessages *DirectMessageService
 	Favorites      *FavoriteService
 	Followers      *FollowerService
@@ -36,7 +36,7 @@ func NewClient(httpClient *http.Client) *Client {
 	return &Client{
 		sling:          base,
 		Accounts:       newAccountService(base.New()),
-		Block:          newBlockService(base.New()),
+		Blocks:         newBlockService(base.New()),
 		DirectMessages: newDirectMessageService(base.New()),
 		Favorites:      newFavoriteService(base.New()),
 		Followers:      newFollowerService(base.New()),


### PR DESCRIPTION
* Fix Client.Block to be Client.Blocks to be consistent with the other client field names

Follows: https://github.com/dghubble/go-twitter/pull/149