### PR TITLE
Drop support for go-twitter library and mark deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-twitter [![GoDoc](https://pkg.go.dev/badge/github.com/dghubble/go-twitter.svg)](https://pkg.go.dev/github.com/dghubble/go-twitter) [![Workflow](https://github.com/dghubble/go-twitter/actions/workflows/test.yaml/badge.svg)](https://github.com/dghubble/go-twitter/actions/workflows/test.yaml?query=branch%3Amain) [![Sponsors](https://img.shields.io/github/sponsors/dghubble?logo=github)](https://github.com/sponsors/dghubble) [![Twitter](https://img.shields.io/badge/twitter-follow-1da1f2?logo=twitter)](https://twitter.com/dghubble)
 
+**DEPRECATED** As of Nov 2022, the go-twitter API library is no longer being developed. If you fork this repo, please remove the logo since it is not covered by the license.
+
 <img align="right" src="https://storage.googleapis.com/dghubble/gopher-on-bird.png">
 
 go-twitter is a Go client library for the [Twitter API](https://dev.twitter.com/rest/public). Check the [usage](#usage) section or try the [examples](/examples) to see how to access the Twitter API.

--- a/twitter/doc.go
+++ b/twitter/doc.go
@@ -1,6 +1,8 @@
 /*
 Package twitter provides a Client for the Twitter API.
 
+Deprecated: This package will no longer be developed.
+
 The twitter package provides a Client for accessing the Twitter API. Here are
 some example requests.
 


### PR DESCRIPTION
* The go-twitter API library will not be developed further or maintained
* The project will be left as-is to allow users to migrate to new platforms, then later archived as read-only

I developed this library in 2015 and have maintained it for the last 7 years. I'm grateful to the 44 contributors and 1 sponsor the project has had at various points. Twitter was a wonderful platform, built by a wonderful team. With its recent changes, its time to re-evaluate what we invest in and the world we want to build. To the 1400+ projects using this library, I'll leave the repo read-only so you can migrate.

All the best,
Dalton